### PR TITLE
Huntress mods view schema

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -309,7 +309,7 @@ module ActiveRecord
       # @param [String] table
       # @return [String]
       def show_create_table(table)
-        do_system_execute("SHOW CREATE TABLE `#{table}`")['data'].try(:first).try(:first).gsub(/[\n\s]+/m, ' ')
+        do_system_execute("SHOW CREATE TABLE `#{table}`")['data'].try(:first).try(:first).gsub(/[\n\s]+/m, ' ').gsub("#{ActiveRecord::Base.connection_db_config.database}.", "")
       end
 
       # Create a new ClickHouse database.

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -34,7 +34,18 @@ HEADER
     end
 
     def tables(stream)
-      sorted_tables = @connection.tables.sort {|a,b| @connection.show_create_table(a).match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) ? 1 : a <=> b }
+      sorted_tables = @connection.tables.sort do |a, b|
+        is_view_a = @connection.show_create_table(a).match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/)
+        is_view_b = @connection.show_create_table(b).match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/)
+
+        if is_view_a && !is_view_b
+          1
+        elsif !is_view_a && is_view_b
+          -1
+        else
+          a <=> b
+        end
+      end
 
       sorted_tables.each do |table_name|
         table(table_name, stream) unless ignored?(table_name)


### PR DESCRIPTION
Remove the database name from the schema dump. This required hackery including the inability to compare the schema between dev and test.
 
Sort the tables alphabetically so they are consistently in the same order. While this was showing the tables first, then the views, the previous sort was returning inconsistent results in different environments.
```ruby
sorted_tables = @connection.tables.sort {|a,b| @connection.show_create_table(a).match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) ? 1 : a <=> b }
```

This (while much more complex) will sort the list so we have tables first, then views last and the tables / views will be sorted alphabetically.
```ruby
sorted_tables = @connection.tables.sort do |a, b|
        is_view_a = @connection.show_create_table(a).match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/)
        is_view_b = @connection.show_create_table(b).match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/)

        if is_view_a && !is_view_b
          1
        elsif !is_view_a && is_view_b
          -1
        else
          a <=> b
        end
      end
```
