### PR TITLE
Add support for Map datatype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 .rspec_status
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ false`. The default integer is `UInt32`
 | UInt64          |          0 to 18446744073709551615           |            5,6,7,8 |
 | UInt256         |                   0 to ...                   |                 8+ |
 | Array           |                     ...                      |                ... |
+| Map             |                     ...                      |                ... |
 
 Example:
 

--- a/lib/active_record/connection_adapters/clickhouse/oid/map.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/map.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module Clickhouse
+      module OID # :nodoc:
+        class Map < Type::Value # :nodoc:
+
+          def initialize(sql_type)
+            @subtype = case sql_type
+                       when /U?Int\d+/
+                         :integer
+                       when /DateTime/
+                         :datetime
+                       when /Date/
+                         :date
+                       else
+                         :string
+            end
+          end
+
+          def type
+            @subtype
+          end
+
+          def deserialize(value)
+            if value.is_a?(::Hash)
+              value.map { |k, item| [k.to_s, deserialize(item)] }.to_h
+            else
+              return value if value.nil?
+              case @subtype
+                when :integer
+                  value.to_i
+                when :datetime
+                  ::DateTime.parse(value)
+                when :date
+                  ::Date.parse(value)
+              else
+                super
+              end
+            end
+          end
+
+          def serialize(value)
+            if value.is_a?(::Hash)
+              value.map { |k, item| [k.to_s, serialize(item)] }.to_h
+            else
+              return value if value.nil?
+              case @subtype
+                when :integer
+                  value.to_i
+                when :datetime
+                  DateTime.new.serialize(value)
+                when :date
+                  Date.new.serialize(value)
+              else
+                super
+              end
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -33,6 +33,9 @@ module ActiveRecord
           if options[:array]
             sql.gsub!(/\s+(.*)/, ' Array(\1)')
           end
+          if options[:map]
+            sql.gsub!(/\s+(.*)/, ' Map(String, \1)')
+          end
           sql.gsub!(/(\sString)\(\d+\)/, '\1')
           sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
           sql

--- a/lib/active_record/connection_adapters/clickhouse/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_definitions.rb
@@ -97,7 +97,7 @@ module ActiveRecord
         private
 
         def valid_column_definition_options
-          super + [:array, :low_cardinality, :fixed_string, :value, :type]
+          super + [:array, :low_cardinality, :fixed_string, :value, :type, :map]
         end
       end
 

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -126,7 +126,7 @@ module ActiveRecord
         # Fix insert_all method
         # https://github.com/PNixx/clickhouse-activerecord/issues/71#issuecomment-1923244983
         def with_yaml_fallback(value) # :nodoc:
-          if value.is_a?(Array)
+          if value.is_a?(Array) || value.is_a?(Hash)
             value
           else
             super

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -8,6 +8,7 @@ require 'active_record/connection_adapters/clickhouse/oid/array'
 require 'active_record/connection_adapters/clickhouse/oid/date'
 require 'active_record/connection_adapters/clickhouse/oid/date_time'
 require 'active_record/connection_adapters/clickhouse/oid/big_integer'
+require 'active_record/connection_adapters/clickhouse/oid/map'
 require 'active_record/connection_adapters/clickhouse/oid/uuid'
 require 'active_record/connection_adapters/clickhouse/schema_definitions'
 require 'active_record/connection_adapters/clickhouse/schema_creation'
@@ -211,6 +212,10 @@ module ActiveRecord
           m.register_type(%r(Array)) do |sql_type|
             Clickhouse::OID::Array.new(sql_type)
           end
+
+          m.register_type(%r(Map)) do |sql_type|
+            Clickhouse::OID::Map.new(sql_type)
+          end
         end
       end
 
@@ -223,6 +228,8 @@ module ActiveRecord
         case value
         when Array
           '[' + value.map { |v| quote(v) }.join(', ') + ']'
+        when Hash
+          '{' + value.map { |k, v| "#{quote(k)}: #{quote(v)}" }.join(', ') + '}'
         else
           super
         end

--- a/spec/fixtures/migrations/add_map_datetime/1_create_verbs_table.rb
+++ b/spec/fixtures/migrations/add_map_datetime/1_create_verbs_table.rb
@@ -1,0 +1,11 @@
+class CreateVerbsTable < ActiveRecord::Migration[7.1]
+  def up
+    create_table :verbs, options: 'MergeTree ORDER BY date', force: true do |t|
+      t.datetime :map_datetime, null: false, map: true
+      t.string :map_string, null: false, map: true
+      t.integer :map_int, null: false, map: true
+      t.date :date, null: false
+    end
+  end
+end
+

--- a/spec/fixtures/migrations/dsl_table_with_fixed_string_creation/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_table_with_fixed_string_creation/1_create_some_table.rb
@@ -5,6 +5,7 @@ class CreateSomeTable < ActiveRecord::Migration[7.1]
     create_table :some, id: false do |t|
       t.string :fixed_string1, fixed_string: 1, null: false
       t.string :fixed_string16_array, fixed_string: 16, array: true, null: true
+      t.string :fixed_string16_map, fixed_string: 16, map: true, null: true
     end
   end
 end

--- a/spec/fixtures/migrations/dsl_table_with_low_cardinality_creation/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_table_with_low_cardinality_creation/1_create_some_table.rb
@@ -6,6 +6,7 @@ class CreateSomeTable < ActiveRecord::Migration[7.1]
       t.string :col1, low_cardinality: true, null: false
       t.string :col2, low_cardinality: true, null: true
       t.string :col3, low_cardinality: true, array: true, null: true
+      t.string :col4, low_cardinality: true, map: true, null: true
     end
   end
 end

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -150,13 +150,15 @@ RSpec.describe 'Migration', :migrations do
 
               current_schema = schema(model)
 
-              expect(current_schema.keys.count).to eq(3)
+              expect(current_schema.keys.count).to eq(4)
               expect(current_schema).to have_key('col1')
               expect(current_schema).to have_key('col2')
               expect(current_schema).to have_key('col3')
+              expect(current_schema).to have_key('col4')
               expect(current_schema['col1'].sql_type).to eq('LowCardinality(String)')
               expect(current_schema['col2'].sql_type).to eq('LowCardinality(Nullable(String))')
               expect(current_schema['col3'].sql_type).to eq('Array(LowCardinality(Nullable(String)))')
+              expect(current_schema['col4'].sql_type).to eq('Map(String, LowCardinality(Nullable(String)))')
             end
           end
 
@@ -167,11 +169,13 @@ RSpec.describe 'Migration', :migrations do
 
               current_schema = schema(model)
 
-              expect(current_schema.keys.count).to eq(2)
+              expect(current_schema.keys.count).to eq(3)
               expect(current_schema).to have_key('fixed_string1')
               expect(current_schema).to have_key('fixed_string16_array')
+              expect(current_schema).to have_key('fixed_string16_map')
               expect(current_schema['fixed_string1'].sql_type).to eq('FixedString(1)')
               expect(current_schema['fixed_string16_array'].sql_type).to eq('Array(Nullable(FixedString(16)))')
+              expect(current_schema['fixed_string16_map'].sql_type).to eq('Map(String, Nullable(FixedString(16)))')
             end
           end
 

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -261,7 +261,6 @@ RSpec.describe 'Model', :migrations do
   end
 
   context 'array' do
-
     let!(:model) do
       Class.new(ActiveRecord::Base) do
         self.table_name = 'actions'
@@ -313,6 +312,62 @@ RSpec.describe 'Model', :migrations do
         expect(event.array_datetime[0].is_a?(DateTime)).to be_truthy
         expect(event.array_datetime[0]).to eq('2022-12-06 15:22:49')
         expect(event.array_datetime[1]).to eq('2022-12-05 15:22:49')
+      end
+    end
+  end
+
+  context 'map' do
+    let!(:model) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = 'verbs'
+      end
+    end
+
+    before do
+      migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'add_map_datetime')
+      quietly { ActiveRecord::MigrationContext.new(migrations_dir, model.connection.schema_migration).up }
+    end
+
+    describe '#create' do
+      it 'creates a new record' do
+        expect {
+          model.create!(
+            map_datetime: {a: 1.day.ago, b: Time.now, c: '2022-12-06 15:22:49'},
+            map_string: {a: 'asdf', b: 'jkl' },
+            map_int: {a: 1, b: 2},
+            date: date
+          )
+        }.to change { model.count }
+        record = model.first
+        expect(record.map_datetime.is_a?(Hash)).to be_truthy
+        expect(record.map_datetime['a'].is_a?(DateTime)).to be_truthy
+        expect(record.map_string['a'].is_a?(String)).to be_truthy
+        expect(record.map_string).to eq({'a' => 'asdf', 'b' => 'jkl'})
+        expect(record.map_int.is_a?(Hash)).to be_truthy
+        expect(record.map_int).to eq({'a' => 1, 'b' => 2})
+      end
+
+      it 'create with insert all' do
+        expect {
+          model.insert_all([{
+            map_datetime: {a: 1.day.ago, b: Time.now, c: '2022-12-06 15:22:49'},
+            map_string: {a: 'asdf', b: 'jkl' },
+            map_int: {a: 1, b: 2},
+            date: date
+          }])
+        }.to change { model.count }
+      end
+
+      it 'get record' do
+        model.connection.insert("INSERT INTO #{model.table_name} (id, map_datetime, date) VALUES (1, {'a': '2022-12-05 15:22:49', 'b': '2022-12-06 15:22:49'}, '2022-12-06')")
+        expect(model.count).to eq(1)
+        record = model.first
+        expect(record.date.is_a?(Date)).to be_truthy
+        expect(record.date).to eq(Date.parse('2022-12-06'))
+        expect(record.map_datetime.is_a?(Hash)).to be_truthy
+        expect(record.map_datetime['a'].is_a?(DateTime)).to be_truthy
+        expect(record.map_datetime['a']).to eq(DateTime.parse('2022-12-05 15:22:49'))
+        expect(record.map_datetime['b']).to eq(DateTime.parse('2022-12-06 15:22:49'))
       end
     end
   end


### PR DESCRIPTION
[Clickhouse Datatype Docs](https://clickhouse.com/docs/en/sql-reference/data-types/map)

Adapted from [this commit](https://github.com/huntresslabs/clickhouse-activerecord/commit/0d9db1d3ab4bac659be4e864e5041bd728807f62) but adapted to be similar to the existing `Array` datatype implementation. The most significant change from the previous implementation and this one is that migrations are defined as such:

```diff
-- t.string "field_name", map: :string, null: false
++ t.string "field_name, map: true, null: false
```

This allows us to rely upon the other datatypes already defined as the `@subtype` by specifying the column type in normal rails style.