### PR TITLE
Switch from `CREATE FUNCTION` to `CREATE OR REPLACE FUNCTION`

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -324,7 +324,7 @@ module ActiveRecord
       end
 
       def create_function(name, body)
-        fd = "CREATE FUNCTION #{apply_cluster(quote_table_name(name))} AS #{body}"
+        fd = "CREATE OR REPLACE FUNCTION #{apply_cluster(quote_table_name(name))} AS #{body}"
         do_execute(fd, format: nil)
       end
 


### PR DESCRIPTION
In a rails app, with existing Clickhouse schema w/a function defined, a `rails db:schema:load` will not always succeed; this is because the function may already exist.

```
Code: 609. DB::Exception: User-defined function 'uuid7ToDateTime' already exists. (FUNCTION_ALREADY_EXISTS) (version 23.9.6.20 (official build))
```

This can be addressed in at least two ways:
1. Guard the `CREATE FUNCTION` statement with `IF NOT EXISTS`; this would prevent trying to create the function, however, it also does not guarantee that the function is up-to-date with the schema
2. Use `CREATE OR REPLACE FUNCTION` instead. This has the benefit of ensuring the function is up-to-date with the schema

This commit pursues option #2.