### PR TITLE
Normalize table name in schema dump

### DIFF
--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -50,7 +50,12 @@ HEADER
         unless simple
           stream.puts "  # TABLE: #{table}"
           sql = @connection.show_create_table(table)
-          stream.puts "  # SQL: #{sql.gsub(/ENGINE = Replicated(.*?)\('[^']+',\s*'[^']+',?\s?([^\)]*)?\)/, "ENGINE = \\1(\\2)")}" if sql
+
+          if sql
+            sql.gsub!(/\A(CREATE\s+[A-Z]+\s+)#{@connection.database}\./, "\\1")
+            sql.gsub!(/ENGINE = Replicated(.*?)\('[^']+',\s*'[^']+',?\s?([^\)]*)?\)/, "ENGINE = \\1(\\2)")
+            stream.puts "  # SQL: #{sql}"
+          end
           # super(table.gsub(/^\.inner\./, ''), stream)
 
           # detect view table


### PR DESCRIPTION
When running separate databases for different environments (i.e. development, test) on the same machine, you will likely specify a different database name in `database.yml`. If you then run migrations in a different ENV, you will get schema changes as the database name will be dumped to the schema comments.

This change strips the database name from the schema, leaving only the table name.

Before:
```ruby
# SQL: CREATE TABLE database_name.table_name
create_table "table_name" ...
```

Afteer:
```ruby
# SQL: CREATE TABLE table_name
create_table "table_name" ...
```