### PR TITLE
SchemaDumper adds materialized view destination

### DIFF
--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -35,7 +35,7 @@ module ClickhouseActiverecord
           # super(table.gsub(/^\.inner\./, ''), stream)
 
           # detect view table
-          match = sql.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/)
+          view_match = sql.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW\s+\S+\s+(TO (\S+))?/)
         end
 
         # Copy from original dumper
@@ -50,8 +50,9 @@ module ClickhouseActiverecord
 
           unless simple
             # Add materialize flag
-            tbl.print ', view: true' if match
-            tbl.print ', materialized: true' if match && match[1].presence
+            tbl.print ', view: true' if view_match
+            tbl.print ', materialized: true' if view_match && view_match[1].presence
+            tbl.print ", to: \"#{view_match[3]}\"" if view_match && view_match[3].presence
           end
 
           case pk
@@ -80,7 +81,7 @@ module ClickhouseActiverecord
           tbl.puts ", force: :cascade do |t|"
 
           # then dump all non-primary key columns
-          if simple || !match
+          if simple || !view_match
             columns.each do |column|
               raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
               next if column.name == pk


### PR DESCRIPTION
This PR updates the SchemaDumper to extract and include the destination table in the `create_table` method for a materialized view. This functionality has existed in the `create_table` method for a while, but was not being parsed by the SchemaDumper when creating the schema file.
