### PR TITLE
Add full support for datetime in aggregate functions

### DIFF
--- a/clickhouse-activerecord.gemspec
+++ b/clickhouse-activerecord.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'pry', '~> 0.12'
+  spec.add_development_dependency 'rails', '>= 7.1.3'
 end

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -177,7 +177,7 @@ module ClickhouseActiverecord
     end
 
     def schema_aggregate_function(column)
-      match = column.sql_type.match(/AggregateFunction\((.+), (\w+)\)/)
+      match = column.sql_type.match(/AggregateFunction\((.+), (\S+)\)/)
 
       return {} if match.nil? || match.size != 3
 

--- a/spec/fixtures/migrations/schema_table_with_aggregate_function_creation/1_create_some_table.rb
+++ b/spec/fixtures/migrations/schema_table_with_aggregate_function_creation/1_create_some_table.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateSomeTable < ActiveRecord::Migration[7.1]
+  def up
+    create_table :some, id: false do |t|
+      t.column :col1, "AggregateFunction(sum, Float32)", null: false
+      t.column :col2, "AggregateFunction(anyLast, Float64)", null: false
+      t.column :col3, "AggregateFunction(anyLast, DateTime64)", null: false
+    end
+  end
+end

--- a/spec/single/schema_dumper_spec.rb
+++ b/spec/single/schema_dumper_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'clickhouse-activerecord/schema_dumper'
+
+RSpec.describe ClickhouseActiverecord::SchemaDumper, :migrations do
+  let(:directory) { raise 'NotImplemented' }
+  let(:migrations_dir) { File.join(FIXTURES_PATH, 'migrations', directory) }
+  let(:migration_context) { ActiveRecord::MigrationContext.new(migrations_dir) }
+
+  before do
+    quietly { migration_context.up }
+  end
+
+  subject do
+    ClickhouseActiverecord::SchemaDumper.dump
+  end
+
+  describe ".dump" do
+    context 'aggregate_function' do
+      let(:directory) { 'schema_table_with_aggregate_function_creation' }
+
+      it 'creates a table with aggregate function column for an Int32' do
+        expect { subject }.to output(
+          satisfy do |schema|
+            expect(schema).to match(/t\.float "col1"/)
+            expect(schema).to match(/"col1"[^\n]+aggregate_function: "sum"/)
+            expect(schema).to match(/"col1"[^\n]+limit: 4/)
+          end
+        ).to_stdout_from_any_process
+      end
+
+      it 'creates a table with aggregate function column for an Int64' do
+        expect { subject }.to output(
+          satisfy do |schema|
+            expect(schema).to match(/t\.float "col2"/)
+            expect(schema).to match(/"col2"[^\n]+aggregate_function: "anyLast"/)
+            expect(schema).to match(/"col2"[^\n]+limit: 8/)
+          end
+        ).to_stdout_from_any_process
+      end
+
+      it 'creates a table with aggregate function column for an DateTime64' do
+        expect { subject }.to output(
+          satisfy do |schema|
+            expect(schema).to match(/t\.datetime "col3"/)
+            expect(schema).to match(/"col3"[^\n]+aggregate_function: "anyLast"/)
+            expect(schema).to match(/"col3"[^\n]+precision: 3/)
+          end
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

Fixes a bug where migrations break when adding 

```ruby
t.column :col3, "AggregateFunction(anyLast, DateTime64)", null: false
```