### PR TITLE
Add support for simple aggregate functions

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -45,6 +45,9 @@ module ActiveRecord
           if options[:aggregate_function]
             sql.gsub!(/(\w+)\s+(.*)/, "\\1 AggregateFunction(#{options[:aggregate_function]}, \\2)")
           end
+          if options[:simple_aggregate_function]
+            sql.gsub!(/(\w+)\s+(.*)/, "\\1 SimpleAggregateFunction(#{options[:simple_aggregate_function]}, \\2)")
+          end
           sql.gsub!(/(\sString)\(\d+\)/, '\1')
           sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
           sql

--- a/lib/active_record/connection_adapters/clickhouse/table_definition.rb
+++ b/lib/active_record/connection_adapters/clickhouse/table_definition.rb
@@ -110,7 +110,7 @@ module ActiveRecord
         private
 
         def valid_column_definition_options
-          super + [:array, :low_cardinality, :fixed_string, :value, :type, :map, :codec, :unsigned, :aggregate_function]
+          super + [:array, :low_cardinality, :fixed_string, :value, :type, :map, :codec, :unsigned, :aggregate_function, :simple_aggregate_function]
         end
       end
 

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -177,13 +177,14 @@ module ClickhouseActiverecord
     end
 
     def schema_aggregate_function(column)
-      match = column.sql_type.match(/AggregateFunction\((.+), (\S+)\)/)
+      match = column.sql_type.match(/((?:Simple|)AggregateFunction)\((.+), (\S+)\)/)
 
-      return {} if match.nil? || match.size != 3
+      return {} if match.nil? || match.size != 4
 
-      { aggregate_function: match[1].inspect }.tap do |spec|
-        spec[:limit] = 4 if match[2] == "Float32"
-        spec[:limit] = 8 if match[2] == "Float64"
+      type = match[1] == "AggregateFunction" ? :aggregate_function : :simple_aggregate_function
+      { type => match[2].inspect }.tap do |spec|
+        spec[:limit] = 4 if match[3] == "Float32"
+        spec[:limit] = 8 if match[3] == "Float64"
       end
     end
 

--- a/spec/fixtures/migrations/schema_table_with_aggregate_function_creation/1_create_some_table.rb
+++ b/spec/fixtures/migrations/schema_table_with_aggregate_function_creation/1_create_some_table.rb
@@ -6,6 +6,7 @@ class CreateSomeTable < ActiveRecord::Migration[7.1]
       t.column :col1, "AggregateFunction(sum, Float32)", null: false
       t.column :col2, "AggregateFunction(anyLast, Float64)", null: false
       t.column :col3, "AggregateFunction(anyLast, DateTime64)", null: false
+      t.column :col4, "SimpleAggregateFunction(anyLast, DateTime64)", null: false
     end
   end
 end

--- a/spec/single/schema_dumper_spec.rb
+++ b/spec/single/schema_dumper_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe ClickhouseActiverecord::SchemaDumper, :migrations do
           end
         ).to_stdout_from_any_process
       end
+
+      it 'creates a table with simple aggregate function column for an DateTime64' do
+        expect { subject }.to output(
+          satisfy do |schema|
+            expect(schema).to match(/t\.datetime "col3"/)
+            expect(schema).to match(/"col3"[^\n]+aggregate_function: "anyLast"/)
+            expect(schema).to match(/"col3"[^\n]+precision: 3/)
+            expect(schema).to match(/t\.datetime "col4", simple_aggregate_function: "anyLast"/)
+          end
+        ).to_stdout_from_any_process
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

Simple Aggregate Functions let you use some aggregate functions with SummingMergeTree and AggregatingMergeTree materialized views without having to use State and Merge suffixes.

e.g.

```ruby
    create_table :mv_target, id: false, options: "SummingMergeTree((total_count_sum, last_timestamp)) do |t|
      t.integer :account_id, limit: 8, null: false
      t.integer :total_count_sum
      t.column :last_timestamp, "SimpleAggregateFunction(anyLast,DateTime64)", null: false
    end
```