### PR TITLE
Add query ID to error response

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -194,7 +194,7 @@ module ActiveRecord
             body = res.body
 
             if body.include?("DB::Exception") && body.match?(DB_EXCEPTION_REGEXP)
-              raise ActiveRecord::ActiveRecordError, "Response code: #{res.code}:\n#{res.body}#{sql ? "\nQuery: #{sql}" : ''}"
+              raise ActiveRecord::ActiveRecordError, "Response code: #{res.code}:\nQuery ID: #{res.header["x-clickhouse-query-id"]}:\n#{res.body}#{sql ? "\nQuery: #{sql}" : ''}"
             else
               format_body_response(res.body, format)
             end
@@ -205,7 +205,7 @@ module ActiveRecord
               when /DB::Exception:.*\(DATABASE_ALREADY_EXISTS\)/
                 raise ActiveRecord::DatabaseAlreadyExists
               else
-                raise ActiveRecord::ActiveRecordError, "Response code: #{res.code}:\n#{res.body}"
+                raise ActiveRecord::ActiveRecordError, "Response code: #{res.code}:\nQuery ID: #{res.header["x-clickhouse-query-id"]}:\n#{res.body}"
             end
           end
         rescue JSON::ParserError


### PR DESCRIPTION
We'd like to be able to correlate individual queries to any of the EOF errors we're seeing. This returns the query ID in all of the error responses so that when we see EOF errors, we can see which specific queries they occurred on.