### PR TITLE
Add query ID to error message

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -21,7 +21,8 @@ module ActiveRecord
         end
 
         def internal_exec_query(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false)
-          result = do_execute(sql, name)
+          query_id = SecureRandom.uuid
+          result = do_execute(sql, name, query_id:)
           columns = result['meta'].map { |m| m['name'] }
           types = {}
           result['meta'].each_with_index do |m, i|
@@ -33,7 +34,7 @@ module ActiveRecord
         rescue ActiveRecord::ActiveRecordError => e
           raise e
         rescue StandardError => e
-          raise ActiveRecord::ActiveRecordError, "Response: #{e.message}"
+          raise ActiveRecord::ActiveRecordError, "Response: #{e.message}. ClickHouse Query ID: #{query_id}"
         end
 
         def exec_insert_all(sql, name)


### PR DESCRIPTION
We're getting an EOFError thousands of times a day and ClickHouse has asked us to give them query IDs to that they can look into it. I previously put in functionality to add the query ID to the raised error, but the one place I missed is the one place throwing all the errors.

This sets a query ID that will be used in the HTTP(S) request and will be in the error message where this is being raised.