### PR TITLE
Add workaround for Clickhouse returning `true` for default values on insert

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/oid/date_time.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/date_time.rb
@@ -10,6 +10,10 @@ module ActiveRecord
             value = super
             return unless value
 
+            # NOTE: Workaround for the bug described in
+            # https://github.com/PNixx/clickhouse-activerecord/issues/174
+            return if value == true
+
             value.strftime('%Y-%m-%d %H:%M:%S' + (@precision.present? && @precision > 0 ? ".%#{@precision}N" : ''))
           end
 


### PR DESCRIPTION
This PR addresses a bug (or at least shortcoming) in Clickhouse that starts causing an error in Rails 8.

The bug/shortcoming is that, for (some?) columns with defaults, the value returned from the DB is "true" instead of the actual value present in the DB. The correct value is returned when the record is reloaded. (This behaviour/bug is described in https://github.com/PNixx/clickhouse-activerecord/issues/174.)

While the correct default value has never actually been returned from the database, this was silently ignored in Rails 7.x and before. With https://github.com/rails/rails/pull/53359, the `true` value starts causing an error for datetime columns (which it should, since `true` is not valid in such columns).