### PR TITLE
Fix flaky `codec` values in schema dumps

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/column.rb
+++ b/lib/active_record/connection_adapters/clickhouse/column.rb
@@ -2,10 +2,9 @@ module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
       class Column < ActiveRecord::ConnectionAdapters::Column
-
         attr_reader :codec
 
-        def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil, codec: nil, **args)
+        def initialize(*, codec: nil, **)
           super
           @codec = codec
         end

--- a/lib/active_record/connection_adapters/clickhouse/column.rb
+++ b/lib/active_record/connection_adapters/clickhouse/column.rb
@@ -10,6 +10,13 @@ module ActiveRecord
           @codec = codec
         end
 
+        def ==(other)
+          other.is_a?(ActiveRecord::ConnectionAdapters::Clickhouse::Column) &&
+            super &&
+            codec == other.codec
+        end
+        alias eql? ==
+
         private
 
         def deduplicated

--- a/spec/single/column_spec.rb
+++ b/spec/single/column_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'active_record/connection_adapters/clickhouse/column'
+
+RSpec.describe ActiveRecord::ConnectionAdapters::Clickhouse::Column do
+  describe '#==' do
+    let(:type_metadata) do
+      instance_double(
+        ActiveRecord::ConnectionAdapters::SqlTypeMetadata,
+        sql_type: 'DateTime64(3)',
+        type: :timestamp,
+        limit: nil,
+        precision: 3,
+        scale: nil
+      )
+    end
+    let(:cast_type) { ActiveRecord::ConnectionAdapters::Clickhouse::OID::DateTime }
+
+    it 'is true when the codec matches' do
+      a = described_class.new('created_at', cast_type, nil, type_metadata, false, nil, codec: 'DoubleDelta, LZ4')
+      b = described_class.new('created_at', cast_type, nil, type_metadata, false, nil, codec: 'DoubleDelta, LZ4')
+
+      expect(a == b).to eql(true)
+    end
+
+    it 'is false when the codec does not match' do
+      a = described_class.new('created_at', cast_type, nil, type_metadata, false, nil, codec: nil)
+      b = described_class.new('created_at', cast_type, nil, type_metadata, false, nil, codec: 'DoubleDelta, LZ4')
+
+      expect(a == b).to eql(false)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes a recurring issue with the handling of columns with `codec` values in the `rails db:schema:dump` task. The root cause is a bug in the upstream `clickhouse-activerecord` that causes some columns to return incorrect cached `Column` instances in `ActiveRecord::ConnectionAdapters::Deduplicable#deduplicate`.

`clickhouse-activerecord` adds a `#codec` attribute to [`ActiveRecord::ConnectionAdapters::Clickhouse::Column`](https://github.com/PNixx/clickhouse-activerecord/blob/master/lib/active_record/connection_adapters/clickhouse/column.rb#L10). However, it does not update the `==`/`eql?` method to include `codec` in the equality check for `Column` instances. (See for comparison the superclass `ActiveRecord::ConnectionAdapters::Column`'s [implementation of `#==`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/column.rb#L78).)

As a result, when the [`ActiveRecord::ConnectionAdapters::Deduplicable#deduplicate`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/deduplicable.rb#L19) method checks its in-memory cache to see if there's a matching `Column` instance, it will re-use a `Column` that has a different `codec` value but otherwise has matching attributes.

This only seems to occur with `rails db:schema:dump` when multiple Clickhouse databases are present; I have not observed it when dumping the schema for only one or the other of our Clickhouse databases (e.g., `rails db:schema:dump:clickhouse_internal`).

Part of [[sc-181441](https://app.shortcut.com/huntress/story/181441/stop-clickhouse-schemas-from-changing-all-the-time-in-portal)].