### PR TITLE
Fix OID::Map incorrectly casting string values when map key type is integer

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/oid/map.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/map.rb
@@ -82,7 +82,7 @@ module ActiveRecord
                 return inner[(i + 1)..].lstrip if depth == 0
               end
             end
-            sql_type
+            inner
           end
 
           def bits_to_limit(bits)

--- a/lib/active_record/connection_adapters/clickhouse/oid/map.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/map.rb
@@ -7,7 +7,8 @@ module ActiveRecord
         class Map < Type::Value # :nodoc:
 
           def initialize(sql_type)
-            case sql_type
+            value_type = extract_map_value_type(sql_type)
+            case value_type
             when /U?Int(\d+)/
               @subtype = :integer
               @limit = bits_to_limit(Regexp.last_match(1)&.to_i)
@@ -67,6 +68,22 @@ module ActiveRecord
           end
 
           private
+
+          def extract_map_value_type(sql_type)
+            inner = sql_type[/\AMap\((.+)\)\z/m, 1]
+            return sql_type unless inner
+
+            depth = 0
+            inner.each_char.with_index do |char, i|
+              case char
+              when '(' then depth += 1
+              when ')' then depth -= 1
+              when ','
+                return inner[(i + 1)..].lstrip if depth == 0
+              end
+            end
+            sql_type
+          end
 
           def bits_to_limit(bits)
             case bits

--- a/spec/oid/map_spec.rb
+++ b/spec/oid/map_spec.rb
@@ -84,4 +84,14 @@ RSpec.describe ActiveRecord::ConnectionAdapters::Clickhouse::OID::Map do
       end
     end
   end
+
+  describe '#serialize' do
+    context 'Map(Int32, String)' do
+      let(:sql_type) { 'Map(Int32, String)' }
+
+      it 'does not cast string values to integers on serialize' do
+        expect(map.serialize({'1' => 'hello'})).to eq({'1' => 'hello'})
+      end
+    end
+  end
 end

--- a/spec/oid/map_spec.rb
+++ b/spec/oid/map_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ActiveRecord::ConnectionAdapters::Clickhouse::OID::Map do
+  subject(:map) { described_class.new(sql_type) }
+
+  describe '#deserialize' do
+    context 'with string key types (Map(String, ...))' do
+      context 'Map(String, String)' do
+        let(:sql_type) { 'Map(String, String)' }
+
+        it 'returns string values unchanged' do
+          expect(map.deserialize({'a' => 'hello', 'b' => 'world'})).to eq({'a' => 'hello', 'b' => 'world'})
+        end
+      end
+
+      context 'Map(String, Int32)' do
+        let(:sql_type) { 'Map(String, Int32)' }
+
+        it 'casts values to integers' do
+          expect(map.deserialize({'a' => '1', 'b' => '2'})).to eq({'a' => 1, 'b' => 2})
+        end
+      end
+
+      context 'Map(String, Array(DateTime))' do
+        let(:sql_type) { 'Map(String, Array(DateTime))' }
+
+        it 'casts array values to DateTime' do
+          result = map.deserialize({'a' => ['2022-01-01 00:00:00']})
+          expect(result['a'].first).to be_a(DateTime)
+        end
+      end
+
+      context 'Map(String, Array(String))' do
+        let(:sql_type) { 'Map(String, Array(String))' }
+
+        it 'returns string array values unchanged' do
+          expect(map.deserialize({'a' => ['str1', 'str2']})).to eq({'a' => ['str1', 'str2']})
+        end
+      end
+    end
+
+    context 'with integer key types (previously buggy)' do
+      context 'Map(Int32, String)' do
+        let(:sql_type) { 'Map(Int32, String)' }
+
+        it 'does not cast string values to integers' do
+          expect(map.deserialize({'1' => 'hello', '2' => 'world'})).to eq({'1' => 'hello', '2' => 'world'})
+        end
+      end
+
+      context 'Map(UInt32, String)' do
+        let(:sql_type) { 'Map(UInt32, String)' }
+
+        it 'does not cast string values to integers' do
+          expect(map.deserialize({'1' => 'foo', '2' => 'bar'})).to eq({'1' => 'foo', '2' => 'bar'})
+        end
+      end
+
+      context 'Map(UInt32, Array(String))' do
+        let(:sql_type) { 'Map(UInt32, Array(String))' }
+
+        it 'does not cast string array values to integers' do
+          expect(map.deserialize({'1' => ['a', 'b'], '2' => ['c']})).to eq({'1' => ['a', 'b'], '2' => ['c']})
+        end
+      end
+
+      context 'Map(Int32, Array(Array(String)))' do
+        let(:sql_type) { 'Map(Int32, Array(Array(String)))' }
+
+        it 'does not cast nested string array values to integers' do
+          input = {'1' => [['foo', 'bar'], ['baz']], '2' => [['qux']]}
+          expect(map.deserialize(input)).to eq({'1' => [['foo', 'bar'], ['baz']], '2' => [['qux']]})
+        end
+      end
+
+      context 'Map(Int64, Int32)' do
+        let(:sql_type) { 'Map(Int64, Int32)' }
+
+        it 'casts values (not keys) to integers' do
+          expect(map.deserialize({'1' => '42', '2' => '7'})).to eq({'1' => 42, '2' => 7})
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `OID::Map#initialize` applied subtype-detection regexes to the **full** sql_type string, causing the key type to match instead of the value type for `Map(Int32, ...)` / `Map(UInt32, ...)` columns
- Leaf string values were cast via `value.to_i`, silently returning `0` for non-numeric strings (e.g. `"foo"` → `0`)
- Fix adds `extract_map_value_type` private helper that walks the type string char-by-char tracking parenthesis depth to extract only the value type before determining `@subtype`

[Original Discussion in Slack](https://huntress.slack.com/archives/C07RD1N6MK3/p1774291813902829)

## Changed files

- `lib/active_record/connection_adapters/clickhouse/oid/map.rb` — one-line change in `initialize` + new private helper method
- `spec/oid/map_spec.rb` — new unit spec (9 examples) covering broken integer-key cases and regression coverage for existing string-key variants

## Control flow / regression risk

The fix is isolated to `OID::Map#initialize`. The `deserialize` and `serialize` methods are unchanged. For `Map(String, ...)` types — all existing tested cases — `extract_map_value_type` returns the value type identically to how the old whole-string regex happened to match, so there is no regression risk for existing behaviour.

[sc-193293]