### PR TITLE
Round-trip table PROJECTIONs through schema dump/load

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -134,6 +134,11 @@ module ActiveRecord
             statements.concat(indexes)
           end
 
+          if o.respond_to?(:projections) && o.projections.any?
+            projections = o.projections.map { |p| visit_ProjectionDefinition(p) }
+            statements.concat(projections)
+          end
+
           create_sql << "(#{statements.join(', ')})" if statements.present?
           # Attach options for only table or materialized view without TO section
           add_table_options!(create_sql, o) if !o.view || o.view && o.materialized && !o.to
@@ -180,6 +185,10 @@ module ActiveRecord
 
         def visit_CreateIndexDefinition(o)
           visit_IndexDefinition(o.index, true)
+        end
+
+        def visit_ProjectionDefinition(o)
+          "PROJECTION #{o.name} (#{o.query})"
         end
 
         def current_database

--- a/lib/active_record/connection_adapters/clickhouse/table_definition.rb
+++ b/lib/active_record/connection_adapters/clickhouse/table_definition.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module Clickhouse
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
 
-        attr_reader :view, :materialized, :if_not_exists, :to
+        attr_reader :view, :materialized, :if_not_exists, :to, :projections
 
         def initialize(
             conn,
@@ -23,6 +23,7 @@ module ActiveRecord
           @conn = conn
           @columns_hash = {}
           @indexes = []
+          @projections = []
           @foreign_keys = []
           @primary_keys = nil
           @temporary = temporary
@@ -34,6 +35,10 @@ module ActiveRecord
           @view = view || materialized
           @materialized = materialized
           @to = to
+        end
+
+        def projection(name, query)
+          @projections << ProjectionDefinition.new(name, query)
         end
 
         def integer(*args, **options)
@@ -111,6 +116,15 @@ module ActiveRecord
 
         def valid_column_definition_options
           super + [:array, :low_cardinality, :fixed_string, :value, :type, :map, :codec, :unsigned, :aggregate_function, :simple_aggregate_function]
+        end
+      end
+
+      class ProjectionDefinition
+        attr_reader :name, :query
+
+        def initialize(name, query)
+          @name = name
+          @query = query
         end
       end
 

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -118,10 +118,14 @@ module ClickhouseActiverecord
         end
 
         indexes = sql.scan(/INDEX \S+ \S+ TYPE .*? GRANULARITY \d+/)
-        if indexes.any?
+        projections = parse_projections(sql)
+        if indexes.any? || projections.any?
           tbl.puts ''
           indexes.flatten.map!(&:strip).each do |index|
             tbl.puts "    t.index #{index_parts(index).join(', ')}"
+          end
+          projections.each do |name, query|
+            tbl.puts "    t.projection #{name.inspect}, #{query.inspect}"
           end
         end
 
@@ -309,6 +313,35 @@ module ClickhouseActiverecord
       spec[:codec] = column.codec.inspect if column.codec
       spec.merge! schema_aggregate_function(column)
       spec.merge(super).compact
+    end
+
+    # Extracts projection definitions from a SHOW CREATE TABLE statement.
+    # ClickHouse emits each projection as `PROJECTION <name> ( <query> )` inside the
+    # column list. The body may itself contain parentheses (function calls,
+    # nested expressions), so we balance parens rather than using a non-greedy regex.
+    # Returns an array of [name, query] pairs with the body trimmed.
+    def parse_projections(sql)
+      results = []
+      offset = 0
+      while (match = sql.match(/PROJECTION (\S+) \(/, offset))
+        name = match[1]
+        body_start = match.end(0)
+        depth = 1
+        i = body_start
+        while i < sql.length && depth.positive?
+          case sql[i]
+          when '(' then depth += 1
+          when ')' then depth -= 1
+          end
+          i += 1
+        end
+        break if depth.positive?
+
+        body = sql[body_start...(i - 1)].strip
+        results << [name, body]
+        offset = i
+      end
+      results
     end
 
     def index_parts(index)

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -318,20 +318,37 @@ module ClickhouseActiverecord
     # Extracts projection definitions from a SHOW CREATE TABLE statement.
     # ClickHouse emits each projection as `PROJECTION <name> ( <query> )` inside the
     # column list. The body may itself contain parentheses (function calls,
-    # nested expressions), so we balance parens rather than using a non-greedy regex.
+    # nested expressions) and SQL string literals containing parens, so we balance
+    # structural parens while skipping over single-quoted strings (with backslash
+    # escape support). The captured name has any surrounding backticks stripped so
+    # round-tripped names compare equal to human-authored DSL names.
     # Returns an array of [name, query] pairs with the body trimmed.
     def parse_projections(sql)
       results = []
       offset = 0
       while (match = sql.match(/PROJECTION (\S+) \(/, offset))
-        name = match[1]
+        name = match[1].delete('`')
         body_start = match.end(0)
         depth = 1
+        in_string = false
+        escaped = false
         i = body_start
         while i < sql.length && depth.positive?
-          case sql[i]
-          when '(' then depth += 1
-          when ')' then depth -= 1
+          ch = sql[i]
+          if escaped
+            escaped = false
+          elsif in_string
+            if ch == "\\"
+              escaped = true
+            elsif ch == "'"
+              in_string = false
+            end
+          else
+            case ch
+            when "'" then in_string = true
+            when '(' then depth += 1
+            when ')' then depth -= 1
+            end
           end
           i += 1
         end

--- a/spec/fixtures/migrations/dsl_create_table_with_projection/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_create_table_with_projection/1_create_some_table.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateSomeTable < ActiveRecord::Migration[7.1]
+  def up
+    create_table :some, options: 'MergeTree PARTITION BY toYYYYMM(date) ORDER BY (date)' do |t|
+      t.integer :int1, null: false
+      t.integer :int2, null: false
+      t.date :date, null: false
+
+      t.projection 'proj_by_int1', 'SELECT * ORDER BY int1, int2'
+      t.projection 'proj_by_int2', 'SELECT * ORDER BY int2, int1'
+    end
+  end
+end

--- a/spec/single/schema_dumper_spec.rb
+++ b/spec/single/schema_dumper_spec.rb
@@ -121,5 +121,27 @@ RSpec.describe ClickhouseActiverecord::SchemaDumper, :migrations do
         ).to_stdout_from_any_process
       end
     end
+
+    context 'projection' do
+      let(:directory) { 'dsl_create_table_with_projection' }
+
+      it 'dumps t.projection entries for each table projection' do
+        expect { subject }.to output(
+          satisfy do |schema|
+            expect(schema).to match(/t\.projection "proj_by_int1", "SELECT \* ORDER BY int1, int2"/)
+            expect(schema).to match(/t\.projection "proj_by_int2", "SELECT \* ORDER BY int2, int1"/)
+          end
+        ).to_stdout_from_any_process
+      end
+
+      it 'creates the projections in ClickHouse so the SQL comment includes them' do
+        expect { subject }.to output(
+          satisfy do |schema|
+            expect(schema).to include('PROJECTION proj_by_int1')
+            expect(schema).to include('PROJECTION proj_by_int2')
+          end
+        ).to_stdout_from_any_process
+      end
+    end
   end
 end

--- a/spec/single/schema_dumper_spec.rb
+++ b/spec/single/schema_dumper_spec.rb
@@ -144,4 +144,52 @@ RSpec.describe ClickhouseActiverecord::SchemaDumper, :migrations do
       end
     end
   end
+
+end
+
+RSpec.describe ClickhouseActiverecord::SchemaDumper, '#parse_projections' do
+  let(:dumper) { ClickhouseActiverecord::SchemaDumper.send(:allocate) }
+
+  it 'extracts a simple projection' do
+    sql = "CREATE TABLE t ( `id` UInt64, PROJECTION p1 ( SELECT * ORDER BY id ) ) ENGINE = MergeTree"
+    expect(dumper.send(:parse_projections, sql)).to eq([['p1', 'SELECT * ORDER BY id']])
+  end
+
+  it 'extracts multiple projections' do
+    sql = "CREATE TABLE t ( `id` UInt64, " \
+          "PROJECTION p1 ( SELECT * ORDER BY id ), " \
+          "PROJECTION p2 ( SELECT * ORDER BY id, id ) ) ENGINE = MergeTree"
+    expect(dumper.send(:parse_projections, sql)).to eq([
+      ['p1', 'SELECT * ORDER BY id'],
+      ['p2', 'SELECT * ORDER BY id, id']
+    ])
+  end
+
+  it 'handles parentheses inside the projection body' do
+    sql = "CREATE TABLE t ( `x` String, PROJECTION p_count ( SELECT count(*), x ORDER BY x ) ) ENGINE = MergeTree"
+    expect(dumper.send(:parse_projections, sql)).to eq([
+      ['p_count', 'SELECT count(*), x ORDER BY x']
+    ])
+  end
+
+  it 'ignores parens inside single-quoted string literals' do
+    sql = "CREATE TABLE t ( `label` String, PROJECTION p_str ( SELECT * WHERE label = '(' ORDER BY label ) ) ENGINE = MergeTree"
+    expect(dumper.send(:parse_projections, sql)).to eq([
+      ['p_str', "SELECT * WHERE label = '(' ORDER BY label"]
+    ])
+  end
+
+  it 'handles backslash-escaped quotes inside string literals' do
+    sql = "CREATE TABLE t ( `label` String, PROJECTION p_esc ( SELECT * WHERE label = 'it\\'s (open' ORDER BY label ) ) ENGINE = MergeTree"
+    expect(dumper.send(:parse_projections, sql)).to eq([
+      ['p_esc', "SELECT * WHERE label = 'it\\'s (open' ORDER BY label"]
+    ])
+  end
+
+  it 'strips backticks from projection names' do
+    sql = "CREATE TABLE t ( `id` UInt64, PROJECTION `weird-name` ( SELECT * ORDER BY id ) ) ENGINE = MergeTree"
+    expect(dumper.send(:parse_projections, sql)).to eq([
+      ['weird-name', 'SELECT * ORDER BY id']
+    ])
+  end
 end


### PR DESCRIPTION
## Summary
- ClickHouse table `PROJECTION` clauses now round-trip through schema dump/load. Previously they appeared in the `# SQL:` comment but were not emitted in the `create_table` block, so loading a dumped schema dropped them — every fresh worktree's `bin/setup` produced a `db/clickhouse_schema.rb` diff against `main`.
- Added `t.projection \"name\", \"query\"` to the `create_table` DSL, wired into `visit_TableDefinition` so the clauses go inside the `CREATE TABLE (...)` along with columns and indexes.
- The dumper parses `PROJECTION` clauses out of `SHOW CREATE TABLE` with paren-balanced extraction so projection bodies containing nested expressions (e.g. function calls) are captured correctly.

## Test plan
- [x] New fixture `dsl_create_table_with_projection` with two projections.
- [x] New specs assert `t.projection` lines appear in the dump and that the SQL comment contains `PROJECTION ...` (i.e. the clauses were actually created in ClickHouse).
- [x] Full `spec/single` suite passes (129 examples, 0 failures).
- [x] Manual end-to-end: loaded Portal's \`logs\` table definition (3 projections) into a fresh ClickHouse database via the new DSL; `SHOW CREATE TABLE` contains all three `PROJECTION` clauses and the resulting dump matches what was loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)