### PR TITLE
Support MATERIALIZED columns in schema dump round-trip

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/column.rb
+++ b/lib/active_record/connection_adapters/clickhouse/column.rb
@@ -4,15 +4,25 @@ module ActiveRecord
       class Column < ActiveRecord::ConnectionAdapters::Column
         attr_reader :codec
 
-        def initialize(*, codec: nil, **)
+        def initialize(*, codec: nil, materialized: false, **)
           super
           @codec = codec
+          @materialized = materialized
+        end
+
+        # True when the column's expression is a MATERIALIZED expression (as
+        # opposed to a plain DEFAULT). The expression itself is carried in
+        # +default_function+; this flag records which kind it is so the schema
+        # dumper can round-trip it as MATERIALIZED rather than DEFAULT.
+        def materialized?
+          @materialized
         end
 
         def ==(other)
           other.is_a?(ActiveRecord::ConnectionAdapters::Clickhouse::Column) &&
             super &&
-            codec == other.codec
+            codec == other.codec &&
+            materialized? == other.materialized?
         end
         alias eql? ==
 

--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -20,12 +20,11 @@ module ActiveRecord
         def add_column_options!(sql, options)
           # When the SQL type is already a complete (Simple)AggregateFunction definition
           # (from t.column with raw SQL type), skip all type-wrapping options to avoid
-          # double-wrapping. Only apply codec and default which are appended, not wrapped.
+          # double-wrapping. Only apply the default/materialized expression and codec,
+          # which are appended, not wrapped.
           if sql.match?(/\s+(Simple)?AggregateFunction\(/)
-            if options[:codec]
-              sql.gsub!(/\s+(.*)/, " \\1 CODEC(#{options[:codec]})")
-            end
-            sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
+            append_default_or_materialized!(sql, options)
+            append_codec!(sql, options)
             return sql
           end
 
@@ -50,9 +49,6 @@ module ActiveRecord
           if options[:map] == true
             sql.gsub!(/\s+(.*)/, ' Map(String, \1)')
           end
-          if options[:codec]
-            sql.gsub!(/\s+(.*)/, " \\1 CODEC(#{options[:codec]})")
-          end
           if options[:aggregate_function]
             sql.gsub!(/(\w+)\s+(.*)/, "\\1 AggregateFunction(#{options[:aggregate_function]}, \\2)")
           end
@@ -61,11 +57,34 @@ module ActiveRecord
           end
           sql.gsub!(/(?<!Fixed)(String)\(\d+\)/, '\1')
 
-          if ::ActiveRecord::version >= Gem::Version.new('8.1')
-            sql << " DEFAULT #{quote_default_expression_for_column_definition(options[:default], options[:column])}" if options_include_default?(options)
-          else
-            sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
+          # ClickHouse column grammar requires the DEFAULT/MATERIALIZED expression
+          # before CODEC(...): `<type> [DEFAULT|MATERIALIZED] <expr> CODEC(...)`.
+          # Appending codec earlier (as a prior implementation did) produces invalid
+          # DDL for any column that has both a codec and an expression.
+          append_default_or_materialized!(sql, options)
+          append_codec!(sql, options)
+          sql
+        end
+
+        # Appends ` MATERIALIZED <expr>` or ` DEFAULT <expr>` to a column definition.
+        # MATERIALIZED takes precedence: a column carries one kind of expression, not both.
+        def append_default_or_materialized!(sql, options)
+          if options[:materialized]
+            sql << " MATERIALIZED #{quote_default_expression(options[:materialized], options[:column])}"
+          elsif options_include_default?(options)
+            if ::ActiveRecord::version >= Gem::Version.new('8.1')
+              sql << " DEFAULT #{quote_default_expression_for_column_definition(options[:default], options[:column])}"
+            else
+              sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}"
+            end
           end
+          sql
+        end
+
+        # Appends ` CODEC(...)`. Must run after append_default_or_materialized! so the
+        # expression precedes the codec, per ClickHouse column grammar.
+        def append_codec!(sql, options)
+          sql << " CODEC(#{options[:codec]})" if options[:codec]
           sql
         end
 

--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -66,6 +66,8 @@ module ActiveRecord
           sql
         end
 
+        private
+
         # Appends ` MATERIALIZED <expr>` or ` DEFAULT <expr>` to a column definition.
         # MATERIALIZED takes precedence: a column carries one kind of expression, not both.
         def append_default_or_materialized!(sql, options)
@@ -87,6 +89,8 @@ module ActiveRecord
           sql << " CODEC(#{options[:codec]})" if options[:codec]
           sql
         end
+
+        public
 
         def add_table_options!(create_sql, options)
           opts = options[:options]

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -259,8 +259,13 @@ module ActiveRecord
         def new_column_from_field(table_name, field, _definitions)
           column_name, sql_type, default_type, default_expression = field
           type_metadata = fetch_type_metadata(sql_type)
+          materialized = default_type == 'MATERIALIZED'
           default_value = extract_value_from_default(default_expression, default_type)
-          default_function = extract_default_function(default_expression)
+          # A MATERIALIZED expression must always ride through as default_function
+          # so the dumper can re-key it to `materialized:`. extract_default_function
+          # only recognises function-shaped expressions, which would silently drop
+          # expressions like `MATERIALIZED a` or `MATERIALIZED a + 1` on round-trip.
+          default_function = materialized ? default_expression.presence : extract_default_function(default_expression)
           cast_type = lookup_cast_type(sql_type)
           default_value = cast_type.cast(default_value)
 
@@ -268,7 +273,7 @@ module ActiveRecord
           args << cast_type if ::ActiveRecord::version >= Gem::Version.new('8.1')
           args += [default_value, type_metadata, field[1].include?('Nullable'), default_function]
 
-          Clickhouse::Column.new(*args, codec: field[5].presence)
+          Clickhouse::Column.new(*args, codec: field[5].presence, materialized: materialized)
         end
 
         def extract_value_from_default(default_expression, default_type)

--- a/lib/active_record/connection_adapters/clickhouse/table_definition.rb
+++ b/lib/active_record/connection_adapters/clickhouse/table_definition.rb
@@ -115,7 +115,7 @@ module ActiveRecord
         private
 
         def valid_column_definition_options
-          super + [:array, :low_cardinality, :fixed_string, :value, :type, :map, :codec, :unsigned, :aggregate_function, :simple_aggregate_function]
+          super + [:array, :low_cardinality, :fixed_string, :value, :type, :map, :codec, :unsigned, :aggregate_function, :simple_aggregate_function, :materialized]
         end
       end
 

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -312,7 +312,16 @@ module ClickhouseActiverecord
       spec[:fixed_string] = schema_fixed_string(column)
       spec[:codec] = column.codec.inspect if column.codec
       spec.merge! schema_aggregate_function(column)
-      spec.merge(super).compact
+      spec = spec.merge(super).compact
+
+      # A MATERIALIZED column's expression is surfaced by the base dumper as
+      # :default (it rides on default_function); re-key it to :materialized so it
+      # round-trips as MATERIALIZED rather than being recreated as a plain DEFAULT.
+      if column.respond_to?(:materialized?) && column.materialized? && spec[:default]
+        spec[:materialized] = spec.delete(:default)
+      end
+
+      spec
     end
 
     # Extracts projection definitions from a SHOW CREATE TABLE statement.

--- a/spec/single/column_spec.rb
+++ b/spec/single/column_spec.rb
@@ -38,5 +38,38 @@ RSpec.describe ActiveRecord::ConnectionAdapters::Clickhouse::Column do
 
       expect(a == b).to eql(false)
     end
+
+    it 'is false when the materialized flag does not match' do
+      a = described_class.new(*column_args('created_at', nil, type_metadata, false, 'now()'), materialized: true)
+      b = described_class.new(*column_args('created_at', nil, type_metadata, false, 'now()'), materialized: false)
+
+      expect(a == b).to eql(false)
+    end
+  end
+
+  describe '#materialized?' do
+    let(:type_metadata) do
+      instance_double(
+        ActiveRecord::ConnectionAdapters::SqlTypeMetadata,
+        sql_type: 'String', type: :string, limit: nil, precision: nil, scale: nil
+      )
+    end
+    let(:cast_type) { double('cast_type', mutable?: false, deserialize: nil) }
+    def column_args(name, default, type_meta, null, default_fn)
+      args = [name]
+      args << cast_type if ActiveRecord.version >= Gem::Version.new('8.1')
+      args += [default, type_meta, null, default_fn]
+      args
+    end
+
+    it 'defaults to false' do
+      column = described_class.new(*column_args('col', nil, type_metadata, false, nil))
+      expect(column.materialized?).to be(false)
+    end
+
+    it 'is true when constructed as materialized' do
+      column = described_class.new(*column_args('col', nil, type_metadata, false, 'now()'), materialized: true)
+      expect(column.materialized?).to be(true)
+    end
   end
 end

--- a/spec/single/materialized_column_spec.rb
+++ b/spec/single/materialized_column_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'clickhouse-activerecord/schema_dumper'
+
+RSpec.describe 'MATERIALIZED column support' do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  # A column with both a codec and an expression. Before the ordering fix this
+  # produced invalid DDL (`<type> CODEC(...) DEFAULT/MATERIALIZED <expr>`), which
+  # failed on creation and made the dumped schema unloadable.
+  def create_mat_test
+    connection.create_table('mat_test', id: false, options: 'MergeTree ORDER BY tuple()') do |t|
+      t.integer :flag, limit: 1, null: false, default: 0
+      t.string :body, null: false, default: ''
+      t.json :doc, codec: 'ZSTD(3)', null: false,
+                   materialized: -> { "if(flag = 1, CAST(body, 'JSON'), CAST('{}', 'JSON'))" }
+    end
+  end
+
+  after do
+    connection.execute('DROP TABLE IF EXISTS mat_test')
+  end
+
+  describe 'DDL generation (expression precedes CODEC)' do
+    it 'emits MATERIALIZED before CODEC' do
+      create_mat_test
+      ddl = connection.show_create_table('mat_test')
+      expect(ddl).to match(/`doc` JSON MATERIALIZED .+ CODEC\(ZSTD\(3\)\)/)
+    end
+
+    it 'emits a plain DEFAULT before CODEC' do
+      connection.create_table('mat_test', id: false, options: 'MergeTree ORDER BY tuple()') do |t|
+        t.integer :id, limit: 8, null: false
+        t.string :name, codec: 'ZSTD(3)', null: false, default: -> { 'toString(id)' }
+      end
+      ddl = connection.show_create_table('mat_test')
+      expect(ddl).to match(/`name` String DEFAULT toString\(id\) CODEC\(ZSTD\(3\)\)/)
+    end
+  end
+
+  describe 'introspection' do
+    before { create_mat_test }
+
+    it 'flags a MATERIALIZED column as materialized and keeps its expression' do
+      doc = connection.columns('mat_test').find { |c| c.name == 'doc' }
+      expect(doc.materialized?).to be(true)
+      expect(doc.default_function).to include('CAST')
+    end
+
+    it 'does not flag a plain DEFAULT column as materialized' do
+      flag = connection.columns('mat_test').find { |c| c.name == 'flag' }
+      expect(flag.materialized?).to be(false)
+    end
+  end
+
+  describe 'schema dump' do
+    before { create_mat_test }
+
+    subject(:dump) do
+      io = StringIO.new
+      ClickhouseActiverecord::SchemaDumper.dump(connection, io)
+      io.string
+    end
+
+    it 'dumps the column as materialized: with its codec, not as default:' do
+      doc_line = dump.lines.find { |l| l.include?('t.json "doc"') }
+      expect(doc_line).to include('codec: "ZSTD(3)"')
+      expect(doc_line).to include(%(materialized: -> { "if(flag = 1, CAST(body, 'JSON'), CAST('{}', 'JSON'))" }))
+      expect(doc_line).not_to include('default:')
+    end
+  end
+
+  describe 'schema dump round-trip' do
+    before { create_mat_test }
+
+    it 'reloads the dumped table definition and preserves the MATERIALIZED column' do
+      io = StringIO.new
+      ClickhouseActiverecord::SchemaDumper.dump(connection, io)
+      create_block = io.string[/create_table "mat_test".*?\n  end/m]
+      expect(create_block).not_to be_nil
+
+      connection.execute('DROP TABLE IF EXISTS mat_test')
+
+      # Re-running the dumped create_table must not raise. Before the fix the
+      # regenerated DDL placed CODEC before the expression, which ClickHouse
+      # rejects. Eval against the connection so create_table/t.json resolve.
+      expect { connection.instance_eval(create_block) }.not_to raise_error
+
+      reloaded = connection.columns('mat_test').find { |c| c.name == 'doc' }
+      expect(reloaded.materialized?).to be(true)
+    end
+  end
+
+  describe 'expression shapes' do
+    it 'round-trips a non-function-shaped MATERIALIZED expression' do
+      # `flag + 1` is not function-shaped, so extract_default_function would miss
+      # it; the expression must still survive the dump as materialized:.
+      connection.create_table('mat_test', id: false, options: 'MergeTree ORDER BY tuple()') do |t|
+        t.integer :flag, limit: 1, null: false, default: 0
+        t.integer :flag_plus_one, limit: 2, null: false, materialized: -> { 'flag + 1' }
+      end
+
+      io = StringIO.new
+      ClickhouseActiverecord::SchemaDumper.dump(connection, io)
+      schema = io.string
+
+      line = schema.lines.find { |l| l.include?('"flag_plus_one"') }
+      expect(line).to include('materialized: -> { "flag + 1" }')
+      expect(line).not_to include('default:')
+
+      create_block = schema[/create_table "mat_test".*?\n  end/m]
+      connection.execute('DROP TABLE IF EXISTS mat_test')
+      expect { connection.instance_eval(create_block) }.not_to raise_error
+      expect(connection.columns('mat_test').find { |c| c.name == 'flag_plus_one' }.materialized?).to be(true)
+    end
+
+    it 'round-trips a MATERIALIZED column without a codec' do
+      connection.create_table('mat_test', id: false, options: 'MergeTree ORDER BY tuple()') do |t|
+        t.integer :flag, limit: 1, null: false, default: 0
+        t.integer :flag_copy, limit: 1, null: false, materialized: -> { 'flag' }
+      end
+
+      io = StringIO.new
+      ClickhouseActiverecord::SchemaDumper.dump(connection, io)
+      schema = io.string
+      expect(schema.lines.find { |l| l.include?('"flag_copy"') }).to include('materialized: -> { "flag" }')
+
+      create_block = schema[/create_table "mat_test".*?\n  end/m]
+      connection.execute('DROP TABLE IF EXISTS mat_test')
+      expect { connection.instance_eval(create_block) }.not_to raise_error
+      expect(connection.columns('mat_test').find { |c| c.name == 'flag_copy' }.materialized?).to be(true)
+    end
+  end
+end

--- a/spec/single/materialized_column_spec.rb
+++ b/spec/single/materialized_column_spec.rb
@@ -8,13 +8,15 @@ RSpec.describe 'MATERIALIZED column support' do
 
   # A column with both a codec and an expression. Before the ordering fix this
   # produced invalid DDL (`<type> CODEC(...) DEFAULT/MATERIALIZED <expr>`), which
-  # failed on creation and made the dumped schema unloadable.
+  # failed on creation and made the dumped schema unloadable. The column type is
+  # incidental (String, to stay portable across ClickHouse versions); what matters
+  # is that it has both a CODEC and a MATERIALIZED expression.
   def create_mat_test
     connection.create_table('mat_test', id: false, options: 'MergeTree ORDER BY tuple()') do |t|
       t.integer :flag, limit: 1, null: false, default: 0
       t.string :body, null: false, default: ''
-      t.json :doc, codec: 'ZSTD(3)', null: false,
-                   materialized: -> { "if(flag = 1, CAST(body, 'JSON'), CAST('{}', 'JSON'))" }
+      t.string :doc, codec: 'ZSTD(3)', null: false,
+                   materialized: -> { "if(flag = 1, upper(body), '')" }
     end
   end
 
@@ -26,7 +28,7 @@ RSpec.describe 'MATERIALIZED column support' do
     it 'emits MATERIALIZED before CODEC' do
       create_mat_test
       ddl = connection.show_create_table('mat_test')
-      expect(ddl).to match(/`doc` JSON MATERIALIZED .+ CODEC\(ZSTD\(3\)\)/)
+      expect(ddl).to match(/`doc` String MATERIALIZED .+ CODEC\(ZSTD\(3\)\)/)
     end
 
     it 'emits a plain DEFAULT before CODEC' do
@@ -45,7 +47,7 @@ RSpec.describe 'MATERIALIZED column support' do
     it 'flags a MATERIALIZED column as materialized and keeps its expression' do
       doc = connection.columns('mat_test').find { |c| c.name == 'doc' }
       expect(doc.materialized?).to be(true)
-      expect(doc.default_function).to include('CAST')
+      expect(doc.default_function).to include('upper(body)')
     end
 
     it 'does not flag a plain DEFAULT column as materialized' do
@@ -64,9 +66,9 @@ RSpec.describe 'MATERIALIZED column support' do
     end
 
     it 'dumps the column as materialized: with its codec, not as default:' do
-      doc_line = dump.lines.find { |l| l.include?('t.json "doc"') }
+      doc_line = dump.lines.find { |l| l.include?('"doc"') }
       expect(doc_line).to include('codec: "ZSTD(3)"')
-      expect(doc_line).to include(%(materialized: -> { "if(flag = 1, CAST(body, 'JSON'), CAST('{}', 'JSON'))" }))
+      expect(doc_line).to include(%(materialized: -> { "if(flag = 1, upper(body), '')" }))
       expect(doc_line).not_to include('default:')
     end
   end


### PR DESCRIPTION
## Problem

A ClickHouse column with **both a CODEC and an expression** could not round-trip through the schema dump:

1. `add_column_options!` appended `CODEC(...)` **before** the expression, but ClickHouse grammar requires `<type> [DEFAULT|MATERIALIZED] <expr> CODEC(...)`. The generated DDL was invalid.
2. A `MATERIALIZED` column was dumped as a plain `DEFAULT`, losing its semantics (and, combined with #1, producing unloadable DDL).

This breaks `db:schema:load` for such columns — which is how test/CI ClickHouse databases are built. It surfaced on a `JSON ... CODEC(ZSTD(3)) MATERIALIZED if(...)` column; no prior column in our schema had both a codec and an expression, so the ordering bug had never been exercised.

## Change

- Carry a `materialized?` flag on `Clickhouse::Column`, set during introspection when `DESCRIBE` reports the `MATERIALIZED` default kind.
- Always carry a MATERIALIZED expression as `default_function` — even when it isn't function-shaped (e.g. `MATERIALIZED a + 1`) — so the dumper never silently drops it.
- Dump a MATERIALIZED column as `materialized: -> { ... }` instead of `default:`.
- Allow `materialized:` as a column-definition option.
- Emit the DEFAULT/MATERIALIZED expression **before** CODEC, in both the main path and the `AggregateFunction` early-return path (extracted `append_default_or_materialized!` / `append_codec!` helpers).

The ordering fix applies to any column with both a codec and an expression, not just materialized ones.

## Tests

`spec/single/column_spec.rb` — the `materialized?` flag (default/true) and equality.
`spec/single/materialized_column_spec.rb` (new) — DDL ordering (MATERIALIZED **and** plain DEFAULT both precede CODEC), introspection, dump output (`materialized:`, not `default:`), a dump→reload round-trip, a non-function-shaped MATERIALIZED expression, and a MATERIALIZED column without a codec.

Full `spec/single`: **146 examples, 0 failures** against ClickHouse 25.10.

## Context

Ports a monkeypatch that huntresslabs/portal carried in an initializer into the gem proper, so portal can drop the patch and rely on the adapter.

## Known follow-up (not in this PR)

`ALIAS` columns have the same dump-as-DEFAULT limitation; this PR scopes to MATERIALIZED. Worth a follow-up if ALIAS columns enter a dumped schema.