### PR TITLE
Merge upstream changes (master) into huntress_mods_8-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 1.6.7 (Mar 5, 2026)
+
+* Fix insert with default values in Ruby 4.0 and Rails 8.1
+
 ### Version 1.6.6 (Feb 16, 2026)
 
 * Fix error: EOFError (end of file reached)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Add `joins_final` to apply the `FINAL` modifier to joined tables (`INNER JOIN <table> FINAL ON ...`), not just the primary `FROM` table
 
+### Version 1.6.7 (Mar 5, 2026)
+
+* Fix insert with default values in Ruby 4.0 and Rails 8.1
+
 ### Version 1.6.6 (Feb 16, 2026)
 
 * Fix error: EOFError (end of file reached)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ default: &default
   port: 8123
   username: username
   password: password
+  http_auth: query_params # optional, supports query_params, basic, x_clickhouse_headers
   ssl: true # optional for using ssl connection
   debug: true # use for showing in to log technical information
   migrations_paths: db/clickhouse # optional, default: db/migrate_clickhouse
@@ -52,6 +53,28 @@ class ActionView < ActiveRecord::Base
   )
 end
 ```
+
+### HTTP authentication mode
+
+By default, the adapter sends `user` and `password` as URL parameters.
+You can set `http_auth` explicitly (or omit it and keep the same default behavior):
+
+```yml
+clickhouse:
+  adapter: clickhouse
+  host: localhost
+  port: 8123
+  database: my_db
+  username: app_user
+  password: secret
+  http_auth: x_clickhouse_headers # or basic / query_params
+```
+
+- Use YAML string values: `http_auth: query_params`, `http_auth: basic`, or `http_auth: x_clickhouse_headers`.
+- Both strings and Ruby symbols are accepted internally.
+- `http_auth: x_clickhouse_headers` sends `X-ClickHouse-User`, `X-ClickHouse-Key`, and `X-ClickHouse-Database` headers.
+- `http_auth: basic` sends `Authorization: Basic ...` and keeps `database` in URL params.
+- `http_auth: query_params` sends `user`, `password`, and `database` in URL params (same as omitting `http_auth`).
 
 ## Usage in Rails
 
@@ -342,6 +365,38 @@ Donations to this project are going directly to [PNixx](https://github.com/PNixx
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+### Run locally
+
+1. Start ClickHouse (single node):
+
+```bash
+docker compose -f .docker/docker-compose.yml up -d
+```
+
+2. Run single-node specs:
+
+```bash
+bin/test-single
+```
+
+If your local workflow expects `bin/single_test`, use the same command format as `bin/test-single`:
+
+```bash
+CLICKHOUSE_PORT=18123 CLICKHOUSE_DATABASE=default bundle exec rspec spec/single --format progress
+```
+
+3. Start ClickHouse cluster:
+
+```bash
+docker compose -f .docker/docker-compose.cluster.yml up -d
+```
+
+4. Run cluster specs:
+
+```bash
+CLICKHOUSE_PORT=28123 CLICKHOUSE_DATABASE=default CLICKHOUSE_CLUSTER=test_cluster bundle exec rspec spec/cluster --format progress
+```
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ default: &default
   port: 8123
   username: username
   password: password
+  http_auth: query_params # optional, supports query_params, basic, x_clickhouse_headers
   ssl: true # optional for using ssl connection
   debug: true # use for showing in to log technical information
   migrations_paths: db/clickhouse # optional, default: db/migrate_clickhouse
@@ -36,6 +37,33 @@ default: &default
   read_timeout: 300 # change network timeouts, by default 60 seconds
   write_timeout: 300
   keep_alive_timeout: 300
+```
+
+### URL-based configuration
+
+You can configure the adapter with a single `url` key instead of individual fields:
+
+```yml
+default: &default
+  adapter: clickhouse
+  url: clickhouse://username:password@localhost:8123/database
+```
+
+Optional settings can be passed as query parameters:
+
+```
+clickhouse://username:password@localhost:8123/database?ssl=true&http_auth=basic&read_timeout=300&write_timeout=300&keep_alive_timeout=300&debug=false&cluster_name=my_cluster
+```
+
+Supported query parameters: `ssl` (true/false), `debug` (true/false), `http_auth` (query_params/basic/x_clickhouse_headers), `read_timeout`, `write_timeout`, `keep_alive_timeout` (integers), `cluster_name`, `sslca`.
+
+If both a `url` and explicit keys are provided, the explicit keys take precedence:
+
+```yml
+default: &default
+  adapter: clickhouse
+  url: clickhouse://username:password@localhost:8123/database
+  host: production.db.internal  # overrides the host from the URL
 ```
 
 Alternatively if you wish to pass a custom `Net::HTTP` transport (or any other
@@ -52,6 +80,28 @@ class ActionView < ActiveRecord::Base
   )
 end
 ```
+
+### HTTP authentication mode
+
+By default, the adapter sends `user` and `password` as URL parameters.
+You can set `http_auth` explicitly (or omit it and keep the same default behavior):
+
+```yml
+clickhouse:
+  adapter: clickhouse
+  host: localhost
+  port: 8123
+  database: my_db
+  username: app_user
+  password: secret
+  http_auth: x_clickhouse_headers # or basic / query_params
+```
+
+- Use YAML string values: `http_auth: query_params`, `http_auth: basic`, or `http_auth: x_clickhouse_headers`.
+- Both strings and Ruby symbols are accepted internally.
+- `http_auth: x_clickhouse_headers` sends `X-ClickHouse-User`, `X-ClickHouse-Key`, and `X-ClickHouse-Database` headers.
+- `http_auth: basic` sends `Authorization: Basic ...` and keeps `database` in URL params.
+- `http_auth: query_params` sends `user`, `password`, and `database` in URL params (same as omitting `http_auth`).
 
 ## Usage in Rails
 
@@ -349,6 +399,38 @@ Donations to this project are going directly to [PNixx](https://github.com/PNixx
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+### Run locally
+
+1. Start ClickHouse (single node):
+
+```bash
+docker compose -f .docker/docker-compose.yml up -d
+```
+
+2. Run single-node specs:
+
+```bash
+bin/test-single
+```
+
+If your local workflow expects `bin/single_test`, use the same command format as `bin/test-single`:
+
+```bash
+CLICKHOUSE_PORT=18123 CLICKHOUSE_DATABASE=default bundle exec rspec spec/single --format progress
+```
+
+3. Start ClickHouse cluster:
+
+```bash
+docker compose -f .docker/docker-compose.cluster.yml up -d
+```
+
+4. Run cluster specs:
+
+```bash
+CLICKHOUSE_PORT=28123 CLICKHOUSE_DATABASE=default CLICKHOUSE_CLUSTER=test_cluster bundle exec rspec spec/cluster --format progress
+```
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ default: &default
   port: 8123
   username: username
   password: password
+  http_auth: query_params # optional, supports query_params, basic, x_clickhouse_headers
   ssl: true # optional for using ssl connection
   debug: true # use for showing in to log technical information
   migrations_paths: db/clickhouse # optional, default: db/migrate_clickhouse
@@ -36,6 +37,33 @@ default: &default
   read_timeout: 300 # change network timeouts, by default 60 seconds
   write_timeout: 300
   keep_alive_timeout: 300
+```
+
+### URL-based configuration
+
+You can configure the adapter with a single `url` key instead of individual fields:
+
+```yml
+default: &default
+  adapter: clickhouse
+  url: clickhouse://username:password@localhost:8123/database
+```
+
+Optional settings can be passed as query parameters:
+
+```
+clickhouse://username:password@localhost:8123/database?ssl=true&http_auth=basic&read_timeout=300&write_timeout=300&keep_alive_timeout=300&debug=false&cluster_name=my_cluster
+```
+
+Supported query parameters: `ssl` (true/false), `debug` (true/false), `http_auth` (query_params/basic/x_clickhouse_headers), `read_timeout`, `write_timeout`, `keep_alive_timeout` (integers), `cluster_name`, `sslca`.
+
+If both a `url` and explicit keys are provided, the explicit keys take precedence:
+
+```yml
+default: &default
+  adapter: clickhouse
+  url: clickhouse://username:password@localhost:8123/database
+  host: production.db.internal  # overrides the host from the URL
 ```
 
 Alternatively if you wish to pass a custom `Net::HTTP` transport (or any other
@@ -52,6 +80,28 @@ class ActionView < ActiveRecord::Base
   )
 end
 ```
+
+### HTTP authentication mode
+
+By default, the adapter sends `user` and `password` as URL parameters.
+You can set `http_auth` explicitly (or omit it and keep the same default behavior):
+
+```yml
+clickhouse:
+  adapter: clickhouse
+  host: localhost
+  port: 8123
+  database: my_db
+  username: app_user
+  password: secret
+  http_auth: x_clickhouse_headers # or basic / query_params
+```
+
+- Use YAML string values: `http_auth: query_params`, `http_auth: basic`, or `http_auth: x_clickhouse_headers`.
+- Both strings and Ruby symbols are accepted internally.
+- `http_auth: x_clickhouse_headers` sends `X-ClickHouse-User`, `X-ClickHouse-Key`, and `X-ClickHouse-Database` headers.
+- `http_auth: basic` sends `Authorization: Basic ...` and keeps `database` in URL params.
+- `http_auth: query_params` sends `user`, `password`, and `database` in URL params (same as omitting `http_auth`).
 
 ## Usage in Rails
 
@@ -342,6 +392,38 @@ Donations to this project are going directly to [PNixx](https://github.com/PNixx
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+### Run locally
+
+1. Start ClickHouse (single node):
+
+```bash
+docker compose -f .docker/docker-compose.yml up -d
+```
+
+2. Run single-node specs:
+
+```bash
+bin/test-single
+```
+
+If your local workflow expects `bin/single_test`, use the same command format as `bin/test-single`:
+
+```bash
+CLICKHOUSE_PORT=18123 CLICKHOUSE_DATABASE=default bundle exec rspec spec/single --format progress
+```
+
+3. Start ClickHouse cluster:
+
+```bash
+docker compose -f .docker/docker-compose.cluster.yml up -d
+```
+
+4. Run cluster specs:
+
+```bash
+CLICKHOUSE_PORT=28123 CLICKHOUSE_DATABASE=default CLICKHOUSE_CLUSTER=test_cluster bundle exec rspec spec/cluster --format progress
+```
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,33 @@ default: &default
   keep_alive_timeout: 300
 ```
 
+### URL-based configuration
+
+You can configure the adapter with a single `url` key instead of individual fields:
+
+```yml
+default: &default
+  adapter: clickhouse
+  url: clickhouse://username:password@localhost:8123/database
+```
+
+Optional settings can be passed as query parameters:
+
+```
+clickhouse://username:password@localhost:8123/database?ssl=true&http_auth=basic&read_timeout=300&write_timeout=300&keep_alive_timeout=300&debug=false&cluster_name=my_cluster
+```
+
+Supported query parameters: `ssl` (true/false), `debug` (true/false), `http_auth` (query_params/basic/x_clickhouse_headers), `read_timeout`, `write_timeout`, `keep_alive_timeout` (integers), `cluster_name`, `sslca`.
+
+If both a `url` and explicit keys are provided, the explicit keys take precedence:
+
+```yml
+default: &default
+  adapter: clickhouse
+  url: clickhouse://username:password@localhost:8123/database
+  host: production.db.internal  # overrides the host from the URL
+```
+
 Alternatively if you wish to pass a custom `Net::HTTP` transport (or any other
 object which supports a `.post()` function with the same parameters as
 `Net::HTTP`'s), you can do this directly instead of specifying

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "clickhouse/activerecord"
+require "clickhouse-activerecord"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/bin/test-single
+++ b/bin/test-single
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CLICKHOUSE_PORT="${CLICKHOUSE_PORT:-18123}"
+export CLICKHOUSE_DATABASE="${CLICKHOUSE_DATABASE:-default}"
+
+exec bundle exec rspec spec/single --format progress "$@"

--- a/lib/active_record/connection_adapters/clickhouse/column.rb
+++ b/lib/active_record/connection_adapters/clickhouse/column.rb
@@ -1,13 +1,26 @@
 module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
-      class Column < ActiveRecord::ConnectionAdapters::Column
-        attr_reader :codec
+      DescribedColumn =
+        Data.define(:name, :sql_type, :default_type, :default_expression, :comment, :codec) do
+          def ephemeral?
+            default_type.to_s.downcase == 'ephemeral'
+          end
+        end
 
-        def initialize(*, codec: nil, materialized: false, **)
+      class Column < ActiveRecord::ConnectionAdapters::Column
+        attr_reader :codec, :default_kind
+
+        def initialize(*, codec: nil, default_kind: nil, **)
           super
           @codec = codec
-          @materialized = materialized
+          @default_kind = ActiveSupport::StringInquirer.new(default_kind.to_s.downcase.presence || 'none')
+        end
+
+        # True when the column is a virtual (computed) column that must be
+        # excluded from INSERT statements: MATERIALIZED and ALIAS columns.
+        def virtual?
+          default_kind.materialized? || default_kind.alias?
         end
 
         # True when the column's expression is a MATERIALIZED expression (as
@@ -15,14 +28,14 @@ module ActiveRecord
         # +default_function+; this flag records which kind it is so the schema
         # dumper can round-trip it as MATERIALIZED rather than DEFAULT.
         def materialized?
-          @materialized
+          default_kind.materialized?
         end
 
         def ==(other)
           other.is_a?(ActiveRecord::ConnectionAdapters::Clickhouse::Column) &&
             super &&
             codec == other.codec &&
-            materialized? == other.materialized?
+            default_kind == other.default_kind
         end
         alias eql? ==
 

--- a/lib/active_record/connection_adapters/clickhouse/column.rb
+++ b/lib/active_record/connection_adapters/clickhouse/column.rb
@@ -1,13 +1,24 @@
 module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
+      DescribedColumn =
+        Data.define(:name, :sql_type, :default_type, :default_expression, :comment, :codec) do
+          def ephemeral?
+            default_type.to_s.downcase == 'ephemeral'
+          end
+        end
+
       class Column < ActiveRecord::ConnectionAdapters::Column
+        attr_reader :codec, :default_kind
 
-        attr_reader :codec
-
-        def initialize(*, codec: nil, **)
+        def initialize(*, codec: nil, default_kind: nil, **)
           super
           @codec = codec
+          @default_kind = ActiveSupport::StringInquirer.new(default_kind.to_s.downcase.presence || 'none')
+        end
+
+        def virtual?
+          default_kind.materialized? || default_kind.alias?
         end
 
         private

--- a/lib/active_record/connection_adapters/clickhouse/oid/map.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/map.rb
@@ -11,6 +11,10 @@ module ActiveRecord
             when /U?Int(\d+)/
               @subtype = :integer
               @limit = bits_to_limit(Regexp.last_match(1)&.to_i)
+            when /Float/
+              @subtype = :float
+            when /Bool/
+              @subtype = :boolean
             when /DateTime/
               @subtype = :datetime
             when /Date/
@@ -34,6 +38,10 @@ module ActiveRecord
               case @subtype
                 when :integer
                   value.to_i
+                when :float
+                  value.to_f
+                when :boolean
+                  ActiveRecord::Type::Boolean.new.cast(value)
                 when :datetime
                   ::DateTime.parse(value)
                 when :date
@@ -51,6 +59,8 @@ module ActiveRecord
               value.map { |item| serialize(item) }
             else
               return value if value.nil?
+              return value.to_f if @subtype == :float
+              return ActiveRecord::Type::Boolean.new.cast(value) if @subtype == :boolean
               case @subtype
                 when :integer
                   value.to_i

--- a/lib/active_record/connection_adapters/clickhouse/oid/map.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/map.rb
@@ -12,6 +12,10 @@ module ActiveRecord
             when /U?Int(\d+)/
               @subtype = :integer
               @limit = bits_to_limit(Regexp.last_match(1)&.to_i)
+            when /Float/
+              @subtype = :float
+            when /Bool/
+              @subtype = :boolean
             when /DateTime/
               @subtype = :datetime
             when /Date/
@@ -32,9 +36,14 @@ module ActiveRecord
               value.map { |item| deserialize(item) }
             else
               return value if value.nil?
+              return value if already_deserialized?(value)
               case @subtype
                 when :integer
                   value.to_i
+                when :float
+                  value.to_f
+                when :boolean
+                  ActiveRecord::Type::Boolean.new.cast(value)
                 when :datetime
                   ::DateTime.parse(value)
                 when :date
@@ -52,6 +61,8 @@ module ActiveRecord
               value.map { |item| serialize(item) }
             else
               return value if value.nil?
+              return value.to_f if @subtype == :float
+              return ActiveRecord::Type::Boolean.new.cast(value) if @subtype == :boolean
               case @subtype
                 when :integer
                   value.to_i
@@ -83,6 +94,11 @@ module ActiveRecord
               end
             end
             inner
+          end
+
+          def already_deserialized?(value)
+            (@subtype == :date && value.is_a?(::Date)) ||
+              (@subtype == :datetime && (value.is_a?(::DateTime) || value.is_a?(::Time)))
           end
 
           def bits_to_limit(bits)

--- a/lib/active_record/connection_adapters/clickhouse/oid/map.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/map.rb
@@ -35,6 +35,7 @@ module ActiveRecord
               value.map { |item| deserialize(item) }
             else
               return value if value.nil?
+              return value if already_deserialized?(value)
               case @subtype
                 when :integer
                   value.to_i
@@ -77,6 +78,11 @@ module ActiveRecord
           end
 
           private
+
+          def already_deserialized?(value)
+            (@subtype == :date && value.is_a?(::Date)) ||
+              (@subtype == :datetime && (value.is_a?(::DateTime) || value.is_a?(::Time)))
+          end
 
           def bits_to_limit(bits)
             case bits

--- a/lib/active_record/connection_adapters/clickhouse/oid/map.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/map.rb
@@ -11,6 +11,10 @@ module ActiveRecord
             when /U?Int(\d+)/
               @subtype = :integer
               @limit = bits_to_limit(Regexp.last_match(1)&.to_i)
+            when /Float/
+              @subtype = :float
+            when /Bool/
+              @subtype = :boolean
             when /DateTime/
               @subtype = :datetime
             when /Date/
@@ -31,9 +35,14 @@ module ActiveRecord
               value.map { |item| deserialize(item) }
             else
               return value if value.nil?
+              return value if already_deserialized?(value)
               case @subtype
                 when :integer
                   value.to_i
+                when :float
+                  value.to_f
+                when :boolean
+                  ActiveRecord::Type::Boolean.new.cast(value)
                 when :datetime
                   ::DateTime.parse(value)
                 when :date
@@ -51,6 +60,8 @@ module ActiveRecord
               value.map { |item| serialize(item) }
             else
               return value if value.nil?
+              return value.to_f if @subtype == :float
+              return ActiveRecord::Type::Boolean.new.cast(value) if @subtype == :boolean
               case @subtype
                 when :integer
                   value.to_i
@@ -67,6 +78,11 @@ module ActiveRecord
           end
 
           private
+
+          def already_deserialized?(value)
+            (@subtype == :date && value.is_a?(::Date)) ||
+              (@subtype == :datetime && (value.is_a?(::DateTime) || value.is_a?(::Time)))
+          end
 
           def bits_to_limit(bits)
             case bits

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
+require 'base64'
 require 'clickhouse-activerecord/version'
 
 module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
       module SchemaStatements
+        HTTP_AUTH_QUERY_PARAMS = :query_params
+        HTTP_AUTH_BASIC = :basic
+        HTTP_AUTH_X_HEADERS = :x_clickhouse_headers
+        HTTP_AUTH_TYPES = [HTTP_AUTH_QUERY_PARAMS, HTTP_AUTH_BASIC, HTTP_AUTH_X_HEADERS].freeze
 
         def with_settings(**settings)
           @block_settings ||= {}
@@ -61,10 +66,7 @@ module ActiveRecord
               statement = Statement.new(sql, format: @response_format)
               result = nil
               @lock.synchronize do
-                req = Net::HTTP::Post.new("/?#{settings_params(settings)}", {
-                  'Content-Type' => 'application/x-www-form-urlencoded',
-                  'User-Agent' => ClickhouseAdapter::USER_AGENT,
-                })
+                req = Net::HTTP::Post.new("/?#{settings_params(settings)}", build_request_headers)
                 @connection.start unless @connection.started?
                 @connection.request(req, statement.formatted_sql) do |response|
                   result = statement.streaming_response(response)
@@ -303,8 +305,7 @@ module ActiveRecord
           @lock.synchronize do
             @connection.post("/?#{settings_params(settings, except: except_params)}",
                              statement.formatted_sql,
-                             'Content-Type' => 'application/x-www-form-urlencoded',
-                             'User-Agent' => ClickhouseAdapter::USER_AGENT)
+                             build_request_headers(include_database: !except_params.include?(:database)))
           end
         end
 
@@ -316,10 +317,39 @@ module ActiveRecord
         def settings_params(settings = {}, except: [])
           request_params = @connection_config || {}
           block_settings = @block_settings || {}
+
+          case @http_auth
+          when HTTP_AUTH_BASIC
+            request_params = request_params.except(:user, :password)
+          when HTTP_AUTH_X_HEADERS
+            request_params = request_params.except(:user, :password, :database)
+          end
+
           request_params.merge(block_settings)
                         .merge(settings)
                         .except(*except)
                         .to_param
+        end
+
+        def build_request_headers(include_database: true)
+          request_headers = {
+            'Content-Type' => 'application/x-www-form-urlencoded',
+            'User-Agent' => ClickhouseAdapter::USER_AGENT
+          }
+
+          case @http_auth
+          when HTTP_AUTH_BASIC
+            if @config[:username] && @config[:password]
+              credentials = Base64.strict_encode64("#{@config[:username]}:#{@config[:password]}")
+              request_headers['Authorization'] = "Basic #{credentials}"
+            end
+          when HTTP_AUTH_X_HEADERS
+            request_headers['X-ClickHouse-User'] = @config[:username].to_s if @config[:username]
+            request_headers['X-ClickHouse-Key'] = @config[:password].to_s if @config[:password]
+            request_headers['X-ClickHouse-Database'] = @config[:database].to_s if include_database && @config[:database]
+          end
+
+          request_headers
         end
 
         # Returns a hash of table names to their engine types

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -78,7 +78,7 @@ module ActiveRecord
         def exec_insert(sql, name = nil, _binds = [], _pk = nil, _sequence_name = nil, returning: nil)
           new_sql = sql.sub(/ (DEFAULT )?VALUES/, " VALUES")
           with_response_format(nil) { execute(new_sql, name) }
-          true
+          nil
         end
 
         def internal_exec_query(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false)

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
+require 'base64'
 require 'clickhouse-activerecord/version'
 
 module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
       module SchemaStatements
+        HTTP_AUTH_QUERY_PARAMS = :query_params
+        HTTP_AUTH_BASIC = :basic
+        HTTP_AUTH_X_HEADERS = :x_clickhouse_headers
+        HTTP_AUTH_TYPES = [HTTP_AUTH_QUERY_PARAMS, HTTP_AUTH_BASIC, HTTP_AUTH_X_HEADERS].freeze
 
         def with_settings(**settings)
           @block_settings ||= {}
@@ -32,14 +37,14 @@ module ActiveRecord
         #   end
         #   # sends and executes "SELECT * FROM table"
         def with_response_format(format)
-          prev_format = @response_format
-          @response_format = format
+          stack = response_format_stack
+          stack.push(format)
           yield
         ensure
-          @response_format = prev_format
+          stack.pop
         end
 
-        def execute(sql, name = nil, format: @response_format, settings: {})
+        def execute(sql, name = nil, format: response_format, settings: {})
           with_response_format(format) do
             log(sql, [adapter_name, name].compact.join(' ')) do
               raw_execute(sql, settings: settings)
@@ -55,16 +60,13 @@ module ActiveRecord
 
         # Execute an SQL query and save the result to a file in stream mode
         # @return [Tempfile]
-        def execute_to_file(sql, name = nil, format: @response_format, settings: {})
+        def execute_to_file(sql, name = nil, format: response_format, settings: {})
           with_response_format(format) do
             log(sql, [adapter_name, 'Stream', name].compact.join(' ')) do
-              statement = Statement.new(sql, format: @response_format)
+              statement = Statement.new(sql, format: response_format)
               result = nil
               @lock.synchronize do
-                req = Net::HTTP::Post.new("/?#{settings_params(settings)}", {
-                  'Content-Type' => 'application/x-www-form-urlencoded',
-                  'User-Agent' => ClickhouseAdapter::USER_AGENT,
-                })
+                req = Net::HTTP::Post.new("/?#{settings_params(settings)}", build_request_headers)
                 @connection.start unless @connection.started?
                 @connection.request(req, statement.formatted_sql) do |response|
                   result = statement.streaming_response(response)
@@ -78,7 +80,7 @@ module ActiveRecord
         def exec_insert(sql, name = nil, _binds = [], _pk = nil, _sequence_name = nil, returning: nil)
           new_sql = sql.sub(/ (DEFAULT )?VALUES/, " VALUES")
           with_response_format(nil) { execute(new_sql, name) }
-          true
+          nil
         end
 
         def internal_exec_query(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false)
@@ -111,7 +113,7 @@ module ActiveRecord
         # @link https://clickhouse.com/docs/en/sql-reference/statements/delete
         def exec_delete(sql, name = nil, _binds = [])
           log(sql, "#{adapter_name} #{name}") do
-            statement = Statement.new(sql, format: @response_format)
+            statement = Statement.new(sql, format: response_format)
             res = request(statement)
             begin
               data = JSON.parse(res.header['x-clickhouse-summary'])
@@ -239,11 +241,23 @@ module ActiveRecord
           result = do_system_execute("DESCRIBE TABLE `#{table_name}`", table_name)
           data = result['data']
 
-          return data unless data.empty?
+          raise ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'" if data.empty?
 
-          raise ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'"
+          data.map do |row|
+            Clickhouse::DescribedColumn.new(
+              name: row[0],
+              sql_type: row[1],
+              default_type: row[2],
+              default_expression: row[3],
+              comment: row[4],
+              codec: row[5],
+            )
+          end
         end
-        alias column_definitions table_structure
+
+        def column_definitions(table_name)
+          table_structure(table_name).reject(&:ephemeral?)
+        end
 
         private
 
@@ -256,18 +270,17 @@ module ActiveRecord
         end
 
         def new_column_from_field(table_name, field, _definitions)
-          column_name, sql_type, default_type, default_expression = field
-          type_metadata = fetch_type_metadata(sql_type)
-          default_value = extract_value_from_default(default_expression, default_type)
-          default_function = extract_default_function(default_expression)
-          cast_type = lookup_cast_type(sql_type)
+          type_metadata = fetch_type_metadata(field.sql_type)
+          default_value = extract_value_from_default(field.default_expression, field.default_type)
+          default_function = extract_default_function(field.default_expression)
+          cast_type = lookup_cast_type(field.sql_type)
           default_value = cast_type.cast(default_value)
 
-          args = [column_name]
+          args = [field.name]
           args << cast_type if ::ActiveRecord::version >= Gem::Version.new('8.1')
-          args += [default_value, type_metadata, field[1].include?('Nullable'), default_function]
+          args += [default_value, type_metadata, field.sql_type.include?('Nullable'), default_function]
 
-          Clickhouse::Column.new(*args, codec: field[5].presence)
+          Clickhouse::Column.new(*args, codec: field.codec.presence, default_kind: field.default_type)
         end
 
         def extract_value_from_default(default_expression, default_type)
@@ -289,7 +302,7 @@ module ActiveRecord
         end
 
         def raw_execute(sql, settings: {}, except_params: [])
-          statement = Statement.new(sql, format: @response_format)
+          statement = Statement.new(sql, format: response_format)
           response = request(statement, settings: settings, except_params: except_params)
           statement.processed_response(response)
         end
@@ -303,8 +316,7 @@ module ActiveRecord
           @lock.synchronize do
             @connection.post("/?#{settings_params(settings, except: except_params)}",
                              statement.formatted_sql,
-                             'Content-Type' => 'application/x-www-form-urlencoded',
-                             'User-Agent' => ClickhouseAdapter::USER_AGENT)
+                             build_request_headers(include_database: !except_params.include?(:database)))
           end
         end
 
@@ -313,13 +325,55 @@ module ActiveRecord
           log(sql, "#{name} (system)") { yield }
         end
 
+        # The response format that should be applied to the next request.
+        # Reads the per-thread override pushed by `with_response_format`, falling
+        # back to the adapter-level default when no override is in scope.
+        def response_format
+          stack = response_format_stack
+          stack.empty? ? @default_response_format : stack.last
+        end
+
+        def response_format_stack
+          key = (@response_format_stack_key ||= :"clickhouse_response_format_stack_#{object_id}")
+          Thread.current[key] ||= []
+        end
+
         def settings_params(settings = {}, except: [])
           request_params = @connection_config || {}
           block_settings = @block_settings || {}
+
+          case @http_auth
+          when HTTP_AUTH_BASIC
+            request_params = request_params.except(:user, :password)
+          when HTTP_AUTH_X_HEADERS
+            request_params = request_params.except(:user, :password, :database)
+          end
+
           request_params.merge(block_settings)
                         .merge(settings)
                         .except(*except)
                         .to_param
+        end
+
+        def build_request_headers(include_database: true)
+          request_headers = {
+            'Content-Type' => 'application/x-www-form-urlencoded',
+            'User-Agent' => ClickhouseAdapter::USER_AGENT
+          }
+
+          case @http_auth
+          when HTTP_AUTH_BASIC
+            if @config[:username] && @config[:password]
+              credentials = Base64.strict_encode64("#{@config[:username]}:#{@config[:password]}")
+              request_headers['Authorization'] = "Basic #{credentials}"
+            end
+          when HTTP_AUTH_X_HEADERS
+            request_headers['X-ClickHouse-User'] = @config[:username].to_s if @config[:username]
+            request_headers['X-ClickHouse-Key'] = @config[:password].to_s if @config[:password]
+            request_headers['X-ClickHouse-Database'] = @config[:database].to_s if include_database && @config[:database]
+          end
+
+          request_headers
         end
 
         # Returns a hash of table names to their engine types

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -241,11 +241,23 @@ module ActiveRecord
           result = do_system_execute("DESCRIBE TABLE `#{table_name}`", table_name)
           data = result['data']
 
-          return data unless data.empty?
+          raise ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'" if data.empty?
 
-          raise ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'"
+          data.map do |row|
+            Clickhouse::DescribedColumn.new(
+              name: row[0],
+              sql_type: row[1],
+              default_type: row[2],
+              default_expression: row[3],
+              comment: row[4],
+              codec: row[5],
+            )
+          end
         end
-        alias column_definitions table_structure
+
+        def column_definitions(table_name)
+          table_structure(table_name).reject(&:ephemeral?)
+        end
 
         private
 
@@ -258,18 +270,17 @@ module ActiveRecord
         end
 
         def new_column_from_field(table_name, field, _definitions)
-          column_name, sql_type, default_type, default_expression = field
-          type_metadata = fetch_type_metadata(sql_type)
-          default_value = extract_value_from_default(default_expression, default_type)
-          default_function = extract_default_function(default_expression)
-          cast_type = lookup_cast_type(sql_type)
+          type_metadata = fetch_type_metadata(field.sql_type)
+          default_value = extract_value_from_default(field.default_expression, field.default_type)
+          default_function = extract_default_function(field.default_expression)
+          cast_type = lookup_cast_type(field.sql_type)
           default_value = cast_type.cast(default_value)
 
-          args = [column_name]
+          args = [field.name]
           args << cast_type if ::ActiveRecord::version >= Gem::Version.new('8.1')
-          args += [default_value, type_metadata, field[1].include?('Nullable'), default_function]
+          args += [default_value, type_metadata, field.sql_type.include?('Nullable'), default_function]
 
-          Clickhouse::Column.new(*args, codec: field[5].presence)
+          Clickhouse::Column.new(*args, codec: field.codec.presence, default_kind: field.default_type)
         end
 
         def extract_value_from_default(default_expression, default_type)

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
+require 'base64'
 require 'clickhouse-activerecord/version'
 
 module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
       module SchemaStatements
+        HTTP_AUTH_QUERY_PARAMS = :query_params
+        HTTP_AUTH_BASIC = :basic
+        HTTP_AUTH_X_HEADERS = :x_clickhouse_headers
+        HTTP_AUTH_TYPES = [HTTP_AUTH_QUERY_PARAMS, HTTP_AUTH_BASIC, HTTP_AUTH_X_HEADERS].freeze
 
         def with_settings(**settings)
           @block_settings ||= {}
@@ -32,14 +37,14 @@ module ActiveRecord
         #   end
         #   # sends and executes "SELECT * FROM table"
         def with_response_format(format)
-          prev_format = @response_format
-          @response_format = format
+          stack = response_format_stack
+          stack.push(format)
           yield
         ensure
-          @response_format = prev_format
+          stack.pop
         end
 
-        def execute(sql, name = nil, format: @response_format, settings: {})
+        def execute(sql, name = nil, format: response_format, settings: {})
           with_response_format(format) do
             log(sql, [adapter_name, name].compact.join(' ')) do
               raw_execute(sql, settings: settings)
@@ -55,16 +60,13 @@ module ActiveRecord
 
         # Execute an SQL query and save the result to a file in stream mode
         # @return [Tempfile]
-        def execute_to_file(sql, name = nil, format: @response_format, settings: {})
+        def execute_to_file(sql, name = nil, format: response_format, settings: {})
           with_response_format(format) do
             log(sql, [adapter_name, 'Stream', name].compact.join(' ')) do
-              statement = Statement.new(sql, format: @response_format)
+              statement = Statement.new(sql, format: response_format)
               result = nil
               @lock.synchronize do
-                req = Net::HTTP::Post.new("/?#{settings_params(settings)}", {
-                  'Content-Type' => 'application/x-www-form-urlencoded',
-                  'User-Agent' => ClickhouseAdapter::USER_AGENT,
-                })
+                req = Net::HTTP::Post.new("/?#{settings_params(settings)}", build_request_headers)
                 @connection.start unless @connection.started?
                 @connection.request(req, statement.formatted_sql) do |response|
                   result = statement.streaming_response(response)
@@ -78,7 +80,7 @@ module ActiveRecord
         def exec_insert(sql, name = nil, _binds = [], _pk = nil, _sequence_name = nil, returning: nil)
           new_sql = sql.sub(/ (DEFAULT )?VALUES/, " VALUES")
           with_response_format(nil) { execute(new_sql, name) }
-          true
+          nil
         end
 
         def internal_exec_query(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false)
@@ -112,7 +114,7 @@ module ActiveRecord
         # @link https://clickhouse.com/docs/en/sql-reference/statements/delete
         def exec_delete(sql, name = nil, _binds = [])
           log(sql, "#{adapter_name} #{name}") do
-            statement = Statement.new(sql, format: @response_format)
+            statement = Statement.new(sql, format: response_format)
             res = request(statement)
             begin
               data = JSON.parse(res.header['x-clickhouse-summary'])
@@ -240,11 +242,23 @@ module ActiveRecord
           result = do_system_execute("DESCRIBE TABLE `#{table_name}`", table_name)
           data = result['data']
 
-          return data unless data.empty?
+          raise ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'" if data.empty?
 
-          raise ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'"
+          data.map do |row|
+            Clickhouse::DescribedColumn.new(
+              name: row[0],
+              sql_type: row[1],
+              default_type: row[2],
+              default_expression: row[3],
+              comment: row[4],
+              codec: row[5],
+            )
+          end
         end
-        alias column_definitions table_structure
+
+        def column_definitions(table_name)
+          table_structure(table_name).reject(&:ephemeral?)
+        end
 
         private
 
@@ -257,23 +271,22 @@ module ActiveRecord
         end
 
         def new_column_from_field(table_name, field, _definitions)
-          column_name, sql_type, default_type, default_expression = field
-          type_metadata = fetch_type_metadata(sql_type)
-          materialized = default_type == 'MATERIALIZED'
-          default_value = extract_value_from_default(default_expression, default_type)
+          type_metadata = fetch_type_metadata(field.sql_type)
+          materialized = field.default_type == 'MATERIALIZED'
+          default_value = extract_value_from_default(field.default_expression, field.default_type)
           # A MATERIALIZED expression must always ride through as default_function
           # so the dumper can re-key it to `materialized:`. extract_default_function
           # only recognises function-shaped expressions, which would silently drop
           # expressions like `MATERIALIZED a` or `MATERIALIZED a + 1` on round-trip.
-          default_function = materialized ? default_expression.presence : extract_default_function(default_expression)
-          cast_type = lookup_cast_type(sql_type)
+          default_function = materialized ? field.default_expression.presence : extract_default_function(field.default_expression)
+          cast_type = lookup_cast_type(field.sql_type)
           default_value = cast_type.cast(default_value)
 
-          args = [column_name]
+          args = [field.name]
           args << cast_type if ::ActiveRecord::version >= Gem::Version.new('8.1')
-          args += [default_value, type_metadata, field[1].include?('Nullable'), default_function]
+          args += [default_value, type_metadata, field.sql_type.include?('Nullable'), default_function]
 
-          Clickhouse::Column.new(*args, codec: field[5].presence, materialized: materialized)
+          Clickhouse::Column.new(*args, codec: field.codec.presence, default_kind: field.default_type)
         end
 
         def extract_value_from_default(default_expression, default_type)
@@ -295,7 +308,7 @@ module ActiveRecord
         end
 
         def raw_execute(sql, settings: {}, except_params: [])
-          statement = Statement.new(sql, format: @response_format)
+          statement = Statement.new(sql, format: response_format)
           response = request(statement, settings: settings, except_params: except_params)
           statement.processed_response(response)
         end
@@ -309,8 +322,7 @@ module ActiveRecord
           @lock.synchronize do
             @connection.post("/?#{settings_params(settings, except: except_params)}",
                              statement.formatted_sql,
-                             'Content-Type' => 'application/x-www-form-urlencoded',
-                             'User-Agent' => ClickhouseAdapter::USER_AGENT)
+                             build_request_headers(include_database: !except_params.include?(:database)))
           end
         end
 
@@ -319,13 +331,55 @@ module ActiveRecord
           log(sql, "#{name} (system)") { yield }
         end
 
+        # The response format that should be applied to the next request.
+        # Reads the per-thread override pushed by `with_response_format`, falling
+        # back to the adapter-level default when no override is in scope.
+        def response_format
+          stack = response_format_stack
+          stack.empty? ? @default_response_format : stack.last
+        end
+
+        def response_format_stack
+          key = (@response_format_stack_key ||= :"clickhouse_response_format_stack_#{object_id}")
+          Thread.current[key] ||= []
+        end
+
         def settings_params(settings = {}, except: [])
           request_params = @connection_config || {}
           block_settings = @block_settings || {}
+
+          case @http_auth
+          when HTTP_AUTH_BASIC
+            request_params = request_params.except(:user, :password)
+          when HTTP_AUTH_X_HEADERS
+            request_params = request_params.except(:user, :password, :database)
+          end
+
           request_params.merge(block_settings)
                         .merge(settings)
                         .except(*except)
                         .to_param
+        end
+
+        def build_request_headers(include_database: true)
+          request_headers = {
+            'Content-Type' => 'application/x-www-form-urlencoded',
+            'User-Agent' => ClickhouseAdapter::USER_AGENT
+          }
+
+          case @http_auth
+          when HTTP_AUTH_BASIC
+            if @config[:username] && @config[:password]
+              credentials = Base64.strict_encode64("#{@config[:username]}:#{@config[:password]}")
+              request_headers['Authorization'] = "Basic #{credentials}"
+            end
+          when HTTP_AUTH_X_HEADERS
+            request_headers['X-ClickHouse-User'] = @config[:username].to_s if @config[:username]
+            request_headers['X-ClickHouse-Key'] = @config[:password].to_s if @config[:password]
+            request_headers['X-ClickHouse-Database'] = @config[:database].to_s if include_database && @config[:database]
+          end
+
+          request_headers
         end
 
         # Returns a hash of table names to their engine types

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -37,14 +37,14 @@ module ActiveRecord
         #   end
         #   # sends and executes "SELECT * FROM table"
         def with_response_format(format)
-          prev_format = @response_format
-          @response_format = format
+          stack = response_format_stack
+          stack.push(format)
           yield
         ensure
-          @response_format = prev_format
+          stack.pop
         end
 
-        def execute(sql, name = nil, format: @response_format, settings: {})
+        def execute(sql, name = nil, format: response_format, settings: {})
           with_response_format(format) do
             log(sql, [adapter_name, name].compact.join(' ')) do
               raw_execute(sql, settings: settings)
@@ -60,10 +60,10 @@ module ActiveRecord
 
         # Execute an SQL query and save the result to a file in stream mode
         # @return [Tempfile]
-        def execute_to_file(sql, name = nil, format: @response_format, settings: {})
+        def execute_to_file(sql, name = nil, format: response_format, settings: {})
           with_response_format(format) do
             log(sql, [adapter_name, 'Stream', name].compact.join(' ')) do
-              statement = Statement.new(sql, format: @response_format)
+              statement = Statement.new(sql, format: response_format)
               result = nil
               @lock.synchronize do
                 req = Net::HTTP::Post.new("/?#{settings_params(settings)}", build_request_headers)
@@ -113,7 +113,7 @@ module ActiveRecord
         # @link https://clickhouse.com/docs/en/sql-reference/statements/delete
         def exec_delete(sql, name = nil, _binds = [])
           log(sql, "#{adapter_name} #{name}") do
-            statement = Statement.new(sql, format: @response_format)
+            statement = Statement.new(sql, format: response_format)
             res = request(statement)
             begin
               data = JSON.parse(res.header['x-clickhouse-summary'])
@@ -302,7 +302,7 @@ module ActiveRecord
         end
 
         def raw_execute(sql, settings: {}, except_params: [])
-          statement = Statement.new(sql, format: @response_format)
+          statement = Statement.new(sql, format: response_format)
           response = request(statement, settings: settings, except_params: except_params)
           statement.processed_response(response)
         end
@@ -323,6 +323,19 @@ module ActiveRecord
         def log_with_debug(sql, name = nil)
           return yield unless @debug
           log(sql, "#{name} (system)") { yield }
+        end
+
+        # The response format that should be applied to the next request.
+        # Reads the per-thread override pushed by `with_response_format`, falling
+        # back to the adapter-level default when no override is in scope.
+        def response_format
+          stack = response_format_stack
+          stack.empty? ? @default_response_format : stack.last
+        end
+
+        def response_format_stack
+          key = (@response_format_stack_key ||= :"clickhouse_response_format_stack_#{object_id}")
+          Thread.current[key] ||= []
         end
 
         def settings_params(settings = {}, except: [])

--- a/lib/active_record/connection_adapters/clickhouse/table_definition.rb
+++ b/lib/active_record/connection_adapters/clickhouse/table_definition.rb
@@ -41,7 +41,7 @@ module ActiveRecord
           unsigned = options[:unsigned]
           unsigned = true if unsigned.nil?
 
-          kind = :uint32 # default
+          kind = unsigned ? :uint32 : :int32 # default
 
           if options[:limit]
             if unsigned

--- a/lib/active_record/connection_adapters/clickhouse/table_definition.rb
+++ b/lib/active_record/connection_adapters/clickhouse/table_definition.rb
@@ -46,7 +46,7 @@ module ActiveRecord
           unsigned = options[:unsigned]
           unsigned = true if unsigned.nil?
 
-          kind = :uint32 # default
+          kind = unsigned ? :uint32 : :int32 # default
 
           if options[:limit]
             if unsigned

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -32,6 +32,13 @@ module ActiveRecord
           raise ArgumentError, 'No database specified. Missing argument: database.'
         end
 
+        if config[:http_auth]
+          unless ConnectionAdapters::Clickhouse::SchemaStatements::HTTP_AUTH_TYPES.include?(config[:http_auth]&.to_sym)
+            raise ArgumentError, "Unknown :http_auth mode #{config[:http_auth].inspect}. " \
+              + "Use one of #{ConnectionAdapters::Clickhouse::SchemaStatements::HTTP_AUTH_TYPES}."
+          end
+        end
+
         ConnectionAdapters::ClickhouseAdapter.new(config)
       end
     end
@@ -143,6 +150,7 @@ module ActiveRecord
         @connection_config = { user: @config[:username], password: @config[:password], database: @config[:database] }.compact
         @debug = @config[:debug] || false
         @response_format = @config[:format] || DEFAULT_RESPONSE_FORMAT
+        @http_auth = @config[:http_auth]&.to_sym
 
         @prepared_statements = false
 

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -312,7 +312,7 @@ module ActiveRecord
         end
 
         pk = table_structure(table_name).first
-        return ['id'] if pk.present? && pk[0] == 'id'
+        return ['id'] if pk.present? && pk.name == 'id'
         []
       end
 
@@ -434,9 +434,9 @@ module ActiveRecord
       end
 
       def change_column_null(table_name, column_name, null, default = nil)
-        structure = table_structure(table_name).select{|v| v[0] == column_name.to_s}.first
+        structure = table_structure(table_name).find { |col| col.name == column_name.to_s }
         raise "Column #{column_name} not found in table #{table_name}" if structure.nil?
-        change_column table_name, column_name, structure[1].gsub(/(Nullable\()?(.*?)\)?/, '\2'), {null: null, default: default}.compact
+        change_column table_name, column_name, structure.sql_type.gsub(/(Nullable\()?(.*?)\)?/, '\2'), {null: null, default: default}.compact
       end
 
       def change_column_default(table_name, column_name, default)

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -20,6 +20,7 @@ require 'active_record/connection_adapters/clickhouse/statement'
 require 'active_record/connection_adapters/clickhouse/table_definition'
 require 'net/http'
 require 'openssl'
+require 'uri'
 
 module ActiveRecord
   class Base
@@ -27,6 +28,11 @@ module ActiveRecord
       # Establishes a connection to the database that's used by all Active Record objects
       def clickhouse_connection(config)
         config = config.symbolize_keys
+
+        if config[:url]
+          url_config = ConnectionAdapters::ClickhouseAdapter.parse_clickhouse_url(config.delete(:url))
+          config = url_config.merge(config)
+        end
 
         unless config.key?(:database)
           raise ArgumentError, 'No database specified. Missing argument: database.'
@@ -128,6 +134,11 @@ module ActiveRecord
 
       # Initializes and connects a Clickhouse adapter.
       def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil)
+        if config_or_deprecated_connection.is_a?(Hash) && config_or_deprecated_connection[:url]
+          config_or_deprecated_connection = config_or_deprecated_connection.dup
+          url_config = self.class.parse_clickhouse_url(config_or_deprecated_connection.delete(:url))
+          config_or_deprecated_connection = url_config.merge(config_or_deprecated_connection)
+        end
         super
         if @config[:connection]
           connection = {
@@ -198,6 +209,37 @@ module ActiveRecord
       end
 
       class << self
+        def parse_clickhouse_url(url)
+          uri = URI.parse(url)
+          config = {}
+
+          config[:host]     = uri.host                                    if uri.host
+          config[:port]     = uri.port                                    if uri.port
+          config[:username] = URI.decode_www_form_component(uri.user)     if uri.user
+          config[:password] = URI.decode_www_form_component(uri.password) if uri.password
+
+          if uri.path && uri.path.length > 1
+            config[:database] = uri.path.delete_prefix('/')
+          end
+
+          if uri.query
+            URI.decode_www_form(uri.query).each do |key, value|
+              case key
+              when 'ssl'                then config[:ssl]                = (value == 'true')
+              when 'debug'              then config[:debug]              = (value == 'true')
+              when 'read_timeout'       then config[:read_timeout]       = value.to_i
+              when 'write_timeout'      then config[:write_timeout]      = value.to_i
+              when 'keep_alive_timeout' then config[:keep_alive_timeout] = value.to_i
+              when 'http_auth'          then config[:http_auth]          = value
+              when 'cluster_name'       then config[:cluster_name]       = value
+              when 'sslca'              then config[:sslca]              = value
+              end
+            end
+          end
+
+          config
+        end
+
         def extract_limit(sql_type) # :nodoc:
           case sql_type
             when /(Nullable)?\(?String\)?/

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -20,6 +20,7 @@ require 'active_record/connection_adapters/clickhouse/statement'
 require 'active_record/connection_adapters/clickhouse/table_definition'
 require 'net/http'
 require 'openssl'
+require 'uri'
 
 module ActiveRecord
   class Base
@@ -28,8 +29,20 @@ module ActiveRecord
       def clickhouse_connection(config)
         config = config.symbolize_keys
 
+        if config[:url]
+          url_config = ConnectionAdapters::ClickhouseAdapter.parse_clickhouse_url(config.delete(:url))
+          config = url_config.merge(config)
+        end
+
         unless config.key?(:database)
           raise ArgumentError, 'No database specified. Missing argument: database.'
+        end
+
+        if config[:http_auth]
+          unless ConnectionAdapters::Clickhouse::SchemaStatements::HTTP_AUTH_TYPES.include?(config[:http_auth]&.to_sym)
+            raise ArgumentError, "Unknown :http_auth mode #{config[:http_auth].inspect}. " \
+              + "Use one of #{ConnectionAdapters::Clickhouse::SchemaStatements::HTTP_AUTH_TYPES}."
+          end
         end
 
         ConnectionAdapters::ClickhouseAdapter.new(config)
@@ -121,6 +134,11 @@ module ActiveRecord
 
       # Initializes and connects a Clickhouse adapter.
       def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil)
+        if config_or_deprecated_connection.is_a?(Hash) && config_or_deprecated_connection[:url]
+          config_or_deprecated_connection = config_or_deprecated_connection.dup
+          url_config = self.class.parse_clickhouse_url(config_or_deprecated_connection.delete(:url))
+          config_or_deprecated_connection = url_config.merge(config_or_deprecated_connection)
+        end
         super
         if @config[:connection]
           connection = {
@@ -142,7 +160,8 @@ module ActiveRecord
 
         @connection_config = { user: @config[:username], password: @config[:password], database: @config[:database] }.compact
         @debug = @config[:debug] || false
-        @response_format = @config[:format] || DEFAULT_RESPONSE_FORMAT
+        @default_response_format = @config[:format] || DEFAULT_RESPONSE_FORMAT
+        @http_auth = @config[:http_auth]&.to_sym
 
         @prepared_statements = false
 
@@ -190,6 +209,37 @@ module ActiveRecord
       end
 
       class << self
+        def parse_clickhouse_url(url)
+          uri = URI.parse(url)
+          config = {}
+
+          config[:host]     = uri.host                                    if uri.host
+          config[:port]     = uri.port                                    if uri.port
+          config[:username] = URI.decode_www_form_component(uri.user)     if uri.user
+          config[:password] = URI.decode_www_form_component(uri.password) if uri.password
+
+          if uri.path && uri.path.length > 1
+            config[:database] = uri.path.delete_prefix('/')
+          end
+
+          if uri.query
+            URI.decode_www_form(uri.query).each do |key, value|
+              case key
+              when 'ssl'                then config[:ssl]                = (value == 'true')
+              when 'debug'              then config[:debug]              = (value == 'true')
+              when 'read_timeout'       then config[:read_timeout]       = value.to_i
+              when 'write_timeout'      then config[:write_timeout]      = value.to_i
+              when 'keep_alive_timeout' then config[:keep_alive_timeout] = value.to_i
+              when 'http_auth'          then config[:http_auth]          = value
+              when 'cluster_name'       then config[:cluster_name]       = value
+              when 'sslca'              then config[:sslca]              = value
+              end
+            end
+          end
+
+          config
+        end
+
         def extract_limit(sql_type) # :nodoc:
           case sql_type
             when /(Nullable)?\(?String\)?/
@@ -304,7 +354,7 @@ module ActiveRecord
         end
 
         pk = table_structure(table_name).first
-        return ['id'] if pk.present? && pk[0] == 'id'
+        return ['id'] if pk.present? && pk.name == 'id'
         []
       end
 
@@ -426,9 +476,9 @@ module ActiveRecord
       end
 
       def change_column_null(table_name, column_name, null, default = nil)
-        structure = table_structure(table_name).select{|v| v[0] == column_name.to_s}.first
+        structure = table_structure(table_name).find { |col| col.name == column_name.to_s }
         raise "Column #{column_name} not found in table #{table_name}" if structure.nil?
-        change_column table_name, column_name, structure[1].gsub(/(Nullable\()?(.*?)\)?/, '\2'), {null: null, default: default}.compact
+        change_column table_name, column_name, structure.sql_type.gsub(/(Nullable\()?(.*?)\)?/, '\2'), {null: null, default: default}.compact
       end
 
       def change_column_default(table_name, column_name, default)
@@ -539,8 +589,13 @@ module ActiveRecord
 
       protected
 
-      def last_inserted_id(result)
-        result
+      def last_inserted_id(_result)
+        # Rails 7.1 persistence.rb:1258:
+        # _write_attribute(column, value)  # wrote true directly — ugly but no crash
+
+        # Rails 8.0 persistence.rb:933:
+        # _write_attribute(column, type_for_attribute(column).deserialize(value))  # now deserializes first
+        nil
       end
 
       def change_column_for_alter(table_name, column_name, type, **options)

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -589,8 +589,13 @@ module ActiveRecord
 
       protected
 
-      def last_inserted_id(result)
-        result
+      def last_inserted_id(_result)
+        # Rails 7.1 persistence.rb:1258:
+        # _write_attribute(column, value)  # wrote true directly — ugly but no crash
+
+        # Rails 8.0 persistence.rb:933:
+        # _write_attribute(column, type_for_attribute(column).deserialize(value))  # now deserializes first
+        nil
       end
 
       def change_column_for_alter(table_name, column_name, type, **options)

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -21,6 +21,7 @@ require 'active_record/connection_adapters/clickhouse/statement'
 require 'active_record/connection_adapters/clickhouse/table_definition'
 require 'net/http'
 require 'openssl'
+require 'uri'
 
 module ActiveRecord
   class Base
@@ -29,8 +30,20 @@ module ActiveRecord
       def clickhouse_connection(config)
         config = config.symbolize_keys
 
+        if config[:url]
+          url_config = ConnectionAdapters::ClickhouseAdapter.parse_clickhouse_url(config.delete(:url))
+          config = url_config.merge(config)
+        end
+
         unless config.key?(:database)
           raise ArgumentError, 'No database specified. Missing argument: database.'
+        end
+
+        if config[:http_auth]
+          unless ConnectionAdapters::Clickhouse::SchemaStatements::HTTP_AUTH_TYPES.include?(config[:http_auth]&.to_sym)
+            raise ArgumentError, "Unknown :http_auth mode #{config[:http_auth].inspect}. " \
+              + "Use one of #{ConnectionAdapters::Clickhouse::SchemaStatements::HTTP_AUTH_TYPES}."
+          end
         end
 
         ConnectionAdapters::ClickhouseAdapter.new(config)
@@ -124,6 +137,11 @@ module ActiveRecord
 
       # Initializes and connects a Clickhouse adapter.
       def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil)
+        if config_or_deprecated_connection.is_a?(Hash) && config_or_deprecated_connection[:url]
+          config_or_deprecated_connection = config_or_deprecated_connection.dup
+          url_config = self.class.parse_clickhouse_url(config_or_deprecated_connection.delete(:url))
+          config_or_deprecated_connection = url_config.merge(config_or_deprecated_connection)
+        end
         super
         if @config[:connection]
           connection = {
@@ -145,7 +163,8 @@ module ActiveRecord
 
         @connection_config = { user: @config[:username], password: @config[:password], database: @config[:database] }.compact
         @debug = @config[:debug] || false
-        @response_format = @config[:format] || DEFAULT_RESPONSE_FORMAT
+        @default_response_format = @config[:format] || DEFAULT_RESPONSE_FORMAT
+        @http_auth = @config[:http_auth]&.to_sym
 
         @prepared_statements = false
 
@@ -193,6 +212,37 @@ module ActiveRecord
       end
 
       class << self
+        def parse_clickhouse_url(url)
+          uri = URI.parse(url)
+          config = {}
+
+          config[:host]     = uri.host                                    if uri.host
+          config[:port]     = uri.port                                    if uri.port
+          config[:username] = URI.decode_www_form_component(uri.user)     if uri.user
+          config[:password] = URI.decode_www_form_component(uri.password) if uri.password
+
+          if uri.path && uri.path.length > 1
+            config[:database] = uri.path.delete_prefix('/')
+          end
+
+          if uri.query
+            URI.decode_www_form(uri.query).each do |key, value|
+              case key
+              when 'ssl'                then config[:ssl]                = (value == 'true')
+              when 'debug'              then config[:debug]              = (value == 'true')
+              when 'read_timeout'       then config[:read_timeout]       = value.to_i
+              when 'write_timeout'      then config[:write_timeout]      = value.to_i
+              when 'keep_alive_timeout' then config[:keep_alive_timeout] = value.to_i
+              when 'http_auth'          then config[:http_auth]          = value
+              when 'cluster_name'       then config[:cluster_name]       = value
+              when 'sslca'              then config[:sslca]              = value
+              end
+            end
+          end
+
+          config
+        end
+
         def extract_limit(sql_type) # :nodoc:
           case sql_type
             when /(Nullable)?\(?String\)?/
@@ -307,7 +357,7 @@ module ActiveRecord
         end
 
         pk = table_structure(table_name).first
-        return ['id'] if pk.present? && pk[0] == 'id'
+        return ['id'] if pk.present? && pk.name == 'id'
         []
       end
 
@@ -429,9 +479,9 @@ module ActiveRecord
       end
 
       def change_column_null(table_name, column_name, null, default = nil)
-        structure = table_structure(table_name).select{|v| v[0] == column_name.to_s}.first
+        structure = table_structure(table_name).find { |col| col.name == column_name.to_s }
         raise "Column #{column_name} not found in table #{table_name}" if structure.nil?
-        change_column table_name, column_name, structure[1].gsub(/(Nullable\()?(.*?)\)?/, '\2'), {null: null, default: default}.compact
+        change_column table_name, column_name, structure.sql_type.gsub(/(Nullable\()?(.*?)\)?/, '\2'), {null: null, default: default}.compact
       end
 
       def change_column_default(table_name, column_name, default)
@@ -542,8 +592,13 @@ module ActiveRecord
 
       protected
 
-      def last_inserted_id(result)
-        result
+      def last_inserted_id(_result)
+        # Rails 7.1 persistence.rb:1258:
+        # _write_attribute(column, value)  # wrote true directly — ugly but no crash
+
+        # Rails 8.0 persistence.rb:933:
+        # _write_attribute(column, type_for_attribute(column).deserialize(value))  # now deserializes first
+        nil
       end
 
       def change_column_for_alter(table_name, column_name, type, **options)

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -149,7 +149,7 @@ module ActiveRecord
 
         @connection_config = { user: @config[:username], password: @config[:password], database: @config[:database] }.compact
         @debug = @config[:debug] || false
-        @response_format = @config[:format] || DEFAULT_RESPONSE_FORMAT
+        @default_response_format = @config[:format] || DEFAULT_RESPONSE_FORMAT
         @http_auth = @config[:http_auth]&.to_sym
 
         @prepared_statements = false

--- a/lib/arel/visitors/clickhouse.rb
+++ b/lib/arel/visitors/clickhouse.rb
@@ -10,8 +10,7 @@ module Arel
       end
 
       def aggregate(name, o, collector)
-        # replacing function name for materialized view
-        if o.expressions.first && o.expressions.first != '*' && !o.expressions.first.is_a?(String) && o.expressions.first.relation&.is_view
+        if o.expressions.first && o.expressions.first != '*' && !o.expressions.first.is_a?(String) && o.expressions.first.respond_to?(:relation) && o.expressions.first.relation&.is_view
           super("#{name.downcase}Merge", o, collector)
         else
           super
@@ -110,7 +109,7 @@ module Arel
         collector << "SETTINGS "
         o.expr.each_with_index do |(key, value), i|
           collector << ", " if i > 0
-          collector << key.to_s.gsub(/\W+/, "")
+          collector << sanitize_as_setting_name(key).to_s
           collector << " = "
           collector << sanitize_as_setting_value(value)
         end
@@ -156,7 +155,7 @@ module Arel
 
       def sanitize_as_setting_name(value)
         return value if Arel::Nodes::SqlLiteral === value
-        @connection.sanitize_as_setting_name(value)
+        value.to_s.gsub(/\W+/, "")
       end
 
       private

--- a/lib/arel/visitors/clickhouse.rb
+++ b/lib/arel/visitors/clickhouse.rb
@@ -10,8 +10,7 @@ module Arel
       end
 
       def aggregate(name, o, collector)
-        # replacing function name for materialized view
-        if o.expressions.first && o.expressions.first != '*' && !o.expressions.first.is_a?(String) && o.expressions.first.relation&.is_view
+        if o.expressions.first && o.expressions.first != '*' && !o.expressions.first.is_a?(String) && o.expressions.first.respond_to?(:relation) && o.expressions.first.relation&.is_view
           super("#{name.downcase}Merge", o, collector)
         else
           super
@@ -100,7 +99,7 @@ module Arel
         collector << "SETTINGS "
         o.expr.each_with_index do |(key, value), i|
           collector << ", " if i > 0
-          collector << key.to_s.gsub(/\W+/, "")
+          collector << sanitize_as_setting_name(key).to_s
           collector << " = "
           collector << sanitize_as_setting_value(value)
         end
@@ -146,7 +145,7 @@ module Arel
 
       def sanitize_as_setting_name(value)
         return value if Arel::Nodes::SqlLiteral === value
-        @connection.sanitize_as_setting_name(value)
+        value.to_s.gsub(/\W+/, "")
       end
 
       private

--- a/lib/clickhouse-activerecord.rb
+++ b/lib/clickhouse-activerecord.rb
@@ -30,5 +30,15 @@ module ClickhouseActiverecord
     Arel::Nodes::SelectStatement.prepend(CoreExtensions::Arel::Nodes::SelectStatement)
     Arel::SelectManager.prepend(CoreExtensions::Arel::SelectManager)
     Arel::Table.prepend(CoreExtensions::Arel::Table)
+
+    # Prevent TimeZoneConverter wrapping for Map OID with DateTime subtype.
+    # Map(String, DateTime) would crash with "Hash values are not supported"
+    # when TimeZoneConverter tries to convert Hash values.
+    ActiveRecord::AttributeMethods::TimeZoneConversion::ClassMethods.prepend(Module.new do
+      def create_time_zone_conversion_attribute?(name, cast_type)
+        return false if cast_type.is_a?(ActiveRecord::ConnectionAdapters::Clickhouse::OID::Map)
+        super
+      end
+    end)
   end
 end

--- a/lib/clickhouse-activerecord/rspec.rb
+++ b/lib/clickhouse-activerecord/rspec.rb
@@ -5,7 +5,7 @@ RSpec.configure do |config|
     original_connection_config = ActiveRecord::Base.connection_db_config
     ActiveRecord::Base.configurations.configurations.select { |x| x.env_name == Rails.env && x.adapter == 'clickhouse' }.each do |db_config|
       ActiveRecord::Base.establish_connection(db_config)
-      ActiveRecord::Base.connection.truncate_tables(*ActiveRecord::Base.connection.tables)
+      ActiveRecord::Base.connection.execute("TRUNCATE ALL TABLES FROM #{db_config.database}")
     end
     ActiveRecord::Base.establish_connection(original_connection_config)
   end

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -99,7 +99,7 @@ module ClickhouseActiverecord
             end
           end
 
-          indexes = sql.scan(/INDEX \S+ \S+ TYPE .*? GRANULARITY \d+/)
+          indexes = sql.scan(/INDEX \S+ .+? TYPE .*? GRANULARITY \d+/)
           if indexes.any?
             tbl.puts ''
             indexes.flatten.map!(&:strip).each do |index|

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -117,7 +117,7 @@ module ClickhouseActiverecord
           end
         end
 
-        indexes = sql.scan(/INDEX \S+ \S+ TYPE .*? GRANULARITY \d+/)
+        indexes = sql.scan(/INDEX \S+ .+? TYPE .*? GRANULARITY \d+/)
         projections = parse_projections(sql)
         if indexes.any? || projections.any?
           tbl.puts ''

--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -34,28 +34,32 @@ module ClickhouseActiverecord
       create
     end
 
-    def structure_dump(*args)
+    def structure_dump(path, *)
       establish_master_connection
 
-      # get all tables
-      tables = connection.execute("SHOW TABLES FROM #{@configuration.database} WHERE name NOT LIKE '.inner_id.%'")['data'].flatten.map do |table|
-        connection.show_create_table(table, single_line: false).gsub("#{@configuration.database}.", '')
-      end.compact
-
-      # sort view to last
-      tables.sort_by! {|table| table.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) ? 1 : 0}
-
       # get all functions
-      functions = connection.execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name")['data'].flatten
+      functions = connection.execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name")['data']
+                            .flatten
+                            .map { |function| function.gsub('\\n', "\n") }
 
-      # put to file
-      File.open(args.first, 'w:utf-8') do |file|
-        functions.each do |function|
-          file.puts function.gsub('\\n', "\n") + ";\n\n"
-        end
+      # get all tables
+      table_defs = connection.execute("SHOW TABLES FROM #{@configuration.database} WHERE name NOT LIKE '.inner_id.%'")['data']
+                             .flatten
+                             .map { |name| connection.show_create_table(name, single_line: false).gsub("#{@configuration.database}.", '') }
 
-        tables.each do |table|
-          file.puts table + ";\n\n"
+      # separate views from tables
+      views, tables = table_defs.partition { |sql| sql.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) }
+
+      # separate materialized from regular views
+      mat_views, views = views.partition { |sql| sql.match(/^CREATE\s+MATERIALIZED\s+VIEW/) }
+
+      # sort: UDFs -> materialized views -> tables -> views
+      ordered_definitions = functions.sort + mat_views.sort + tables.sort + views.sort
+
+      # puts to file
+      File.open(path, 'w:utf-8') do |file|
+        ordered_definitions.each do |sql|
+          file.puts "#{sql};\n\n"
         end
       end
     end

--- a/lib/clickhouse-activerecord/version.rb
+++ b/lib/clickhouse-activerecord/version.rb
@@ -1,3 +1,3 @@
 module ClickhouseActiverecord
-  VERSION = '1.6.6'
+  VERSION = '1.6.7'
 end

--- a/spec/cluster/migration_spec.rb
+++ b/spec/cluster/migration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Cluster Migration', :migrations do
+RSpec.describe 'Cluster Migration', :migrations, cluster: true do
   describe 'performs migrations' do
     let(:model) do
       Class.new(ActiveRecord::Base) do

--- a/spec/fixtures/migrations/add_map_datetime/1_create_verbs_table.rb
+++ b/spec/fixtures/migrations/add_map_datetime/1_create_verbs_table.rb
@@ -2,6 +2,7 @@ class CreateVerbsTable < ActiveRecord::Migration[7.1]
   def up
     create_table :verbs, options: 'MergeTree ORDER BY date', force: true do |t|
       t.datetime :map_datetime, null: false, map: true
+      t.date :map_date, null: false, map: true
       t.string :map_string, null: false, map: true
       t.integer :map_int, null: false, map: true
 

--- a/spec/fixtures/migrations/add_map_float_bool/1_create_map_test_table.rb
+++ b/spec/fixtures/migrations/add_map_float_bool/1_create_map_test_table.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateMapTestTable < ActiveRecord::Migration[7.1]
+  def up
+    create_table :map_test, options: 'MergeTree ORDER BY date', force: true do |t|
+      t.column :map_float32, 'Map(String, Float32)', null: false
+      t.column :map_float64, 'Map(String, Float64)', null: false
+      t.column :map_bool, 'Map(String, Bool)', null: false
+      t.date :date, null: false
+    end
+  end
+end

--- a/spec/fixtures/migrations/add_sample_data/1_create_sample_table.rb
+++ b/spec/fixtures/migrations/add_sample_data/1_create_sample_table.rb
@@ -12,6 +12,7 @@ class CreateSampleTable < ActiveRecord::Migration[7.1]
       t.string :byte_array
       t.uuid :relation_uuid
       t.decimal :decimal_value, precision: 38, scale: 16
+      t.datetime :ver, precision: 3, default: -> { 'now64()' }, null: false
     end
   end
 end

--- a/spec/fixtures/migrations/dsl_create_table_with_index/4_create_simple_index.rb
+++ b/spec/fixtures/migrations/dsl_create_table_with_index/4_create_simple_index.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CreateSimpleIndex < ActiveRecord::Migration[7.1]
+  def up
+    add_index :some, 'date', name: 'simple_idx', type: 'minmax', granularity: 1
+  end
+end

--- a/spec/fixtures/migrations/dsl_table_with_integer_creation/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_table_with_integer_creation/1_create_some_table.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateSomeTable < ActiveRecord::Migration[7.1]
+  def up
+    create_table :some, id: false do |t|
+      t.integer :default_int
+      t.integer :signed_no_limit, unsigned: false, null: false, default: -1
+      t.integer :signed_small, unsigned: false, limit: 1, null: false, default: -1
+      t.integer :signed_int32, unsigned: false, limit: 4, null: false, default: -1
+      t.integer :signed_int64, unsigned: false, limit: 8, null: false, default: -1
+      t.integer :unsigned_tiny, unsigned: true, limit: 1, null: false, default: 0
+    end
+  end
+end

--- a/spec/fixtures/migrations/mat_view/1_create_events_table.rb
+++ b/spec/fixtures/migrations/mat_view/1_create_events_table.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateEventsTable < ActiveRecord::Migration[5.0]
+  def up
+    create_table :events, options: 'MergeTree ORDER BY (date, event_name)' do |t|
+      t.string :event_name, null: false
+      t.date :date, null: false
+    end
+  end
+end

--- a/spec/fixtures/migrations/mat_view/2_create_event_dates_view.rb
+++ b/spec/fixtures/migrations/mat_view/2_create_event_dates_view.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateEventDatesView < ActiveRecord::Migration[5.0]
+  def up
+    ActiveRecord::Base.connection.execute(<<~SQL.squish)
+      CREATE MATERIALIZED VIEW event_dates
+      ENGINE = AggregatingMergeTree()
+      ORDER BY date
+      AS SELECT date,
+                sumState(id) AS ids
+      FROM events
+      GROUP BY date
+    SQL
+  end
+end

--- a/spec/single/column_default_types_spec.rb
+++ b/spec/single/column_default_types_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Column default types', :migrations do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  before do
+    connection.execute('DROP TABLE IF EXISTS column_default_types_test')
+    connection.execute(<<~SQL.squish)
+      CREATE TABLE column_default_types_test (
+        id UInt64,
+        name String DEFAULT '',
+        computed String MATERIALIZED upper(name),
+        scratch UInt64 EPHEMERAL 0,
+        display String ALIAS lower(name)
+      ) ENGINE = MergeTree ORDER BY id
+    SQL
+  end
+
+  after do
+    connection.execute('DROP TABLE IF EXISTS column_default_types_test')
+  end
+
+  let!(:model) do
+    Class.new(ActiveRecord::Base) do
+      self.table_name = 'column_default_types_test'
+    end
+  end
+
+  describe 'Column#default_kind' do
+    it 'is default? for DEFAULT columns' do
+      col = model.columns_hash['name']
+      expect(col.default_kind).to be_default
+    end
+
+    it 'is materialized? for MATERIALIZED columns' do
+      col = model.columns_hash['computed']
+      expect(col.default_kind).to be_materialized
+    end
+
+    it 'is alias? for ALIAS columns' do
+      col = model.columns_hash['display']
+      expect(col.default_kind).to be_alias
+    end
+
+    it 'is none? for plain columns' do
+      col = model.columns_hash['id']
+      expect(col.default_kind).to be_none
+    end
+
+    it 'does not expose EPHEMERAL columns in columns_hash' do
+      expect(model.columns_hash).not_to have_key('scratch')
+    end
+  end
+
+  describe 'INSERT behavior' do
+    it 'creates a record successfully (excludes MATERIALIZED and ALIAS from INSERT)' do
+      expect {
+        model.create!(id: 1, name: 'hello')
+      }.to change { model.count }.by(1)
+    end
+
+    it 'excludes MATERIALIZED columns even when dirtied' do
+      record = model.new(id: 3, name: 'dirty')
+      record[:computed] = 'MANUAL'
+      expect { record.save! }.not_to raise_error
+    end
+
+    it 'excludes ALIAS columns even when dirtied' do
+      record = model.new(id: 4, name: 'dirty')
+      record[:display] = 'manual'
+      expect { record.save! }.not_to raise_error
+    end
+
+    it 'creates a record with insert_all' do
+      expect {
+        model.insert_all([{ id: 2, name: 'world' }])
+      }.to change { model.count }.by(1)
+    end
+  end
+
+  describe 'SELECT behavior' do
+    before { model.create!(id: 1, name: 'Hello') }
+
+    it 'SELECT * does not include MATERIALIZED or ALIAS columns' do
+      record = model.first
+      expect(record.attributes).to include('id', 'name')
+      expect(record.attributes).not_to include('computed', 'display')
+    end
+
+    it 'MATERIALIZED columns can be selected explicitly' do
+      record = model.select(:id, :computed).first
+      expect(record.computed).to eq('HELLO')
+    end
+
+    it 'ALIAS columns can be selected explicitly' do
+      record = model.select(:id, :display).first
+      expect(record.display).to eq('hello')
+    end
+  end
+
+  describe 'WHERE behavior' do
+    before { model.create!(id: 1, name: 'Hello') }
+
+    it 'can filter on MATERIALIZED columns' do
+      record = model.select(:id, :computed).where(computed: 'HELLO').first
+      expect(record).to be_present
+      expect(record.computed).to eq('HELLO')
+    end
+
+    it 'can filter on ALIAS columns' do
+      record = model.select(:id, :display).where(display: 'hello').first
+      expect(record).to be_present
+      expect(record.display).to eq('hello')
+    end
+  end
+end

--- a/spec/single/column_spec.rb
+++ b/spec/single/column_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe ActiveRecord::ConnectionAdapters::Clickhouse::Column do
       expect(a == b).to eql(false)
     end
 
-    it 'is false when the materialized flag does not match' do
-      a = described_class.new(*column_args('created_at', nil, type_metadata, false, 'now()'), materialized: true)
-      b = described_class.new(*column_args('created_at', nil, type_metadata, false, 'now()'), materialized: false)
+    it 'is false when the default_kind does not match' do
+      a = described_class.new(*column_args('created_at', nil, type_metadata, false, 'now()'), default_kind: 'MATERIALIZED')
+      b = described_class.new(*column_args('created_at', nil, type_metadata, false, 'now()'), default_kind: 'DEFAULT')
 
       expect(a == b).to eql(false)
     end
@@ -68,7 +68,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::Clickhouse::Column do
     end
 
     it 'is true when constructed as materialized' do
-      column = described_class.new(*column_args('col', nil, type_metadata, false, 'now()'), materialized: true)
+      column = described_class.new(*column_args('col', nil, type_metadata, false, 'now()'), default_kind: 'MATERIALIZED')
       expect(column.materialized?).to be(true)
     end
   end

--- a/spec/single/http_auth_spec.rb
+++ b/spec/single/http_auth_spec.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'uri'
+
+RSpec.describe 'HTTP auth modes' do
+  let(:http_connection) { instance_double(Net::HTTP) }
+  let(:response_body) { '' }
+  let(:response) { instance_double(Net::HTTPResponse, code: '200', body: response_body) }
+  let(:base_config) do
+    {
+      adapter: 'clickhouse',
+      host: 'localhost',
+      port: 8123,
+      database: 'test_db',
+      username: 'app_user',
+      password: 'secret'
+    }
+  end
+  let(:request_settings) { { max_threads: 1 } }
+  let(:target_database) { 'analytics' }
+  let(:config) { base_config }
+  subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+  before do
+    allow(Net::HTTP).to receive(:start).and_return(http_connection)
+    allow(http_connection).to receive(:keep_alive_timeout=)
+    allow(http_connection).to receive(:started?).and_return(true)
+    allow(http_connection).to receive(:post).and_return(response)
+  end
+
+  def request_payload_for(settings: request_settings)
+    request_payload = {}
+
+    allow(http_connection).to receive(:post) do |path, _body, headers|
+      request_payload[:query_params] = query_params(path)
+      request_payload[:headers] = headers
+
+      response
+    end
+
+    adapter.execute('SELECT 1', settings: settings)
+    request_payload
+  end
+
+  def query_params(path)
+    query = path.split('?', 2).last.to_s
+    URI.decode_www_form(query).to_h
+  end
+
+  def json_compact_each_row(names:, types:, rows:)
+    ([names, types] + rows).map(&:to_json).join("\n")
+  end
+
+  context 'default mode' do
+    it 'uses url query auth' do
+      payload = request_payload_for
+
+      expect(payload[:query_params]).to include(
+        'user' => config[:username],
+        'password' => config[:password],
+        'database' => config[:database],
+        'max_threads' => request_settings[:max_threads].to_s
+      )
+      expect(payload[:headers]).to_not have_key('Authorization')
+      expect(payload[:headers]).to_not have_key('X-ClickHouse-User')
+    end
+  end
+
+  context 'query params mode' do
+    let(:config) { base_config.merge(http_auth: :query_params) }
+
+    it 'uses url query auth explicitly' do
+      payload = request_payload_for
+
+      expect(payload[:query_params]).to include(
+        'user' => config[:username],
+        'password' => config[:password],
+        'database' => config[:database],
+        'max_threads' => request_settings[:max_threads].to_s
+      )
+      expect(payload[:headers]).to_not have_key('Authorization')
+      expect(payload[:headers]).to_not have_key('X-ClickHouse-User')
+    end
+
+    context 'mode as string' do
+      let(:config) { base_config.merge(http_auth: 'query_params') }
+
+      it 'uses url query auth explicitly' do
+        payload = request_payload_for
+
+        expect(payload[:query_params]).to include(
+          'user' => config[:username],
+          'password' => config[:password],
+          'database' => config[:database]
+        )
+        expect(payload[:headers]).to_not have_key('Authorization')
+        expect(payload[:headers]).to_not have_key('X-ClickHouse-User')
+      end
+    end
+  end
+
+  context 'basic auth mode' do
+    let(:config) { base_config.merge(http_auth: :basic) }
+
+    it 'uses Authorization header' do
+      payload = request_payload_for
+
+      expect(payload[:query_params]).to include(
+        'database' => config[:database],
+        'max_threads' => request_settings[:max_threads].to_s
+      )
+      expect(payload[:query_params]).to_not have_key('user')
+      expect(payload[:query_params]).to_not have_key('password')
+      expect(payload[:headers]['Authorization']).to eq("Basic #{Base64.strict_encode64("#{config[:username]}:#{config[:password]}")}")
+    end
+
+    it 'uses Authorization header for create_database' do
+      adapter.create_database(target_database)
+
+      expect(http_connection).to have_received(:post) do |path, _body, headers|
+        params = query_params(path)
+
+        expect(params).to_not have_key('user')
+        expect(params).to_not have_key('password')
+        expect(params).to_not have_key('database')
+        expect(headers['Authorization']).to eq("Basic #{Base64.strict_encode64("#{config[:username]}:#{config[:password]}")}")
+      end
+    end
+
+    it 'uses Authorization header for drop_database' do
+      adapter.drop_database(target_database)
+
+      expect(http_connection).to have_received(:post) do |path, _body, headers|
+        params = query_params(path)
+
+        expect(params).to_not have_key('user')
+        expect(params).to_not have_key('password')
+        expect(params).to_not have_key('database')
+        expect(headers['Authorization']).to eq("Basic #{Base64.strict_encode64("#{config[:username]}:#{config[:password]}")}")
+      end
+    end
+
+    it 'uses Authorization header for system queries' do
+      allow(http_connection).to receive(:post) do |path, _body, headers|
+        expect(query_params(path)).to_not have_key('user')
+        expect(query_params(path)).to_not have_key('password')
+        expect(headers['Authorization']).to eq("Basic #{Base64.strict_encode64("#{config[:username]}:#{config[:password]}")}")
+        instance_double(Net::HTTPResponse, code: '200',
+                                           body: json_compact_each_row(names: ['name'], types: ['String'], rows: [['events']]))
+      end
+
+      expect(adapter.tables).to eq(['events'])
+      expect(adapter.views).to eq(['events'])
+    end
+
+    context 'mode as string' do
+      let(:config) { base_config.merge(http_auth: 'basic') }
+
+      it 'uses Authorization header' do
+        payload = request_payload_for
+
+        expect(payload[:query_params]).to_not have_key('user')
+        expect(payload[:query_params]).to_not have_key('password')
+        expect(payload[:headers]['Authorization']).to eq("Basic #{Base64.strict_encode64("#{config[:username]}:#{config[:password]}")}")
+      end
+    end
+
+    context 'without username/password' do
+      let(:config) { base_config.merge(username: nil, password: nil, http_auth: :basic) }
+
+      it 'does not send Authorization header' do
+        payload = request_payload_for
+
+        expect(payload[:query_params]).to include(
+          'database' => config[:database],
+          'max_threads' => request_settings[:max_threads].to_s
+        )
+        expect(payload[:query_params]).to_not have_key('user')
+        expect(payload[:query_params]).to_not have_key('password')
+        expect(payload[:headers]).to_not have_key('Authorization')
+      end
+    end
+  end
+
+  context 'x-clickhouse headers mode' do
+    let(:config) { base_config.merge(http_auth: :x_clickhouse_headers) }
+
+    it 'uses X-ClickHouse auth headers' do
+      payload = request_payload_for
+
+      expect(payload[:query_params]).to include('max_threads' => request_settings[:max_threads].to_s)
+      expect(payload[:query_params]).to_not have_key('user')
+      expect(payload[:query_params]).to_not have_key('password')
+      expect(payload[:query_params]).to_not have_key('database')
+
+      expect(payload[:headers]).to include(
+        'X-ClickHouse-User' => config[:username],
+        'X-ClickHouse-Key' => config[:password],
+        'X-ClickHouse-Database' => config[:database]
+      )
+    end
+
+    context 'mode as string' do
+      let(:config) { base_config.merge(http_auth: 'x_clickhouse_headers') }
+
+      it 'uses X-ClickHouse auth headers' do
+        payload = request_payload_for
+
+        expect(payload[:query_params]).to_not have_key('user')
+        expect(payload[:query_params]).to_not have_key('password')
+        expect(payload[:query_params]).to_not have_key('database')
+
+        expect(payload[:headers]).to include(
+          'X-ClickHouse-User' => config[:username],
+          'X-ClickHouse-Key' => config[:password],
+          'X-ClickHouse-Database' => config[:database]
+        )
+      end
+    end
+
+    it 'does not include database auth context for create_database' do
+      adapter.create_database(target_database)
+
+      expect(http_connection).to have_received(:post) do |_path, _body, headers|
+        expect(headers).to_not have_key('X-ClickHouse-Database')
+
+        expect(headers).to include(
+          'X-ClickHouse-User' => config[:username],
+          'X-ClickHouse-Key' => config[:password]
+        )
+      end
+    end
+
+    it 'does not include database auth context for drop_database' do
+      adapter.drop_database(target_database)
+
+      expect(http_connection).to have_received(:post) do |_path, _body, headers|
+        expect(headers).to_not have_key('X-ClickHouse-Database')
+
+        expect(headers).to include(
+          'X-ClickHouse-User' => config[:username],
+          'X-ClickHouse-Key' => config[:password]
+        )
+      end
+    end
+
+    it 'uses auth headers for execute_to_file requests' do
+      streaming_response = instance_double(Net::HTTPResponse, code: '200')
+
+      allow(http_connection).to receive(:request) do |request, _sql, &callback|
+        params = query_params(request.path)
+        expect(params).to include('max_threads' => request_settings[:max_threads].to_s)
+        expect(params).to_not have_key('user')
+        expect(params).to_not have_key('password')
+        expect(params).to_not have_key('database')
+
+        expect(request['X-ClickHouse-User']).to eq(config[:username])
+        expect(request['X-ClickHouse-Key']).to eq(config[:password])
+        expect(request['X-ClickHouse-Database']).to eq(config[:database])
+
+        allow(streaming_response).to receive(:read_body).and_yield("id\n1\n")
+        callback.call(streaming_response)
+      end
+
+      file = adapter.execute_to_file('SELECT 1', settings: request_settings)
+      expect(file.read).to eq("id\n1\n")
+      file.close!
+    end
+
+    context 'without username/password' do
+      let(:config) { base_config.merge(username: nil, password: nil, http_auth: :x_clickhouse_headers) }
+
+      it 'does not send empty auth headers' do
+        payload = request_payload_for
+
+        expect(payload[:query_params]).to include('max_threads' => request_settings[:max_threads].to_s)
+        expect(payload[:query_params]).to_not have_key('user')
+        expect(payload[:query_params]).to_not have_key('password')
+        expect(payload[:query_params]).to_not have_key('database')
+
+        expect(payload[:headers]).to_not have_key('X-ClickHouse-User')
+        expect(payload[:headers]).to_not have_key('X-ClickHouse-Key')
+        expect(payload[:headers]['X-ClickHouse-Database']).to eq(config[:database])
+      end
+    end
+  end
+
+  context 'invalid mode' do
+    it 'raises argument error' do
+      expect do
+        ActiveRecord::Base.clickhouse_connection(base_config.merge(http_auth: :unsupported))
+      end.to raise_error(ArgumentError, /Unknown :http_auth mode/)
+    end
+  end
+end

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -331,6 +331,25 @@ RSpec.describe 'Migration', :migrations do
 
             ActiveRecord::Base.connection.clear_index('some', 'idx2')
           end
+
+          it 'dumps indexes' do
+            require 'clickhouse-activerecord/schema_dumper'
+
+            quietly { migration_context.up(1) }
+
+            current_schema = StringIO.new
+            ClickhouseActiverecord::SchemaDumper.dump(ActiveRecord::Base.connection, current_schema)
+
+            expect(current_schema.string).to include('t.index "(int1 * int2, date)", name: "idx", type: "minmax", granularity: 3')
+
+            quietly { migration_context.up(4) }
+
+            current_schema = StringIO.new
+            ClickhouseActiverecord::SchemaDumper.dump(ActiveRecord::Base.connection, current_schema)
+
+            expect(current_schema.string).to include('t.index "int1 * int2", name: "idx2", type: "set(10)", granularity: 4')
+            expect(current_schema.string).to include('t.index "date", name: "simple_idx", type: "minmax", granularity: 1')
+          end
         end
       end
     end

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -96,6 +96,26 @@ RSpec.describe 'Migration', :migrations do
         end
 
         context 'types' do
+          context 'integer' do
+            let(:directory) { 'dsl_table_with_integer_creation' }
+            it 'honors unsigned: false even when limit is omitted' do
+              subject
+
+              current_schema = schema(model)
+
+              expect(current_schema['default_int'].sql_type).to eq('Nullable(UInt32)')
+              expect(current_schema['signed_no_limit'].sql_type).to eq('Int32')
+              expect(current_schema['signed_no_limit'].default).to eq(-1)
+              expect(current_schema['signed_small'].sql_type).to eq('Int8')
+              expect(current_schema['signed_small'].default).to eq(-1)
+              expect(current_schema['signed_int32'].sql_type).to eq('Int32')
+              expect(current_schema['signed_int32'].default).to eq(-1)
+              expect(current_schema['signed_int64'].sql_type).to eq('Int64')
+              expect(current_schema['signed_int64'].default).to eq(-1)
+              expect(current_schema['unsigned_tiny'].sql_type).to eq('UInt8')
+            end
+          end
+
           context 'decimal' do
             let(:directory) { 'dsl_table_with_decimal_creation' }
             it 'creates a table with valid scale and precision' do
@@ -310,6 +330,25 @@ RSpec.describe 'Migration', :migrations do
             subject
 
             ActiveRecord::Base.connection.clear_index('some', 'idx2')
+          end
+
+          it 'dumps indexes' do
+            require 'clickhouse-activerecord/schema_dumper'
+
+            quietly { migration_context.up(1) }
+
+            current_schema = StringIO.new
+            ClickhouseActiverecord::SchemaDumper.dump(ActiveRecord::Base.connection, current_schema)
+
+            expect(current_schema.string).to include('t.index "(int1 * int2, date)", name: "idx", type: "minmax", granularity: 3')
+
+            quietly { migration_context.up(4) }
+
+            current_schema = StringIO.new
+            ClickhouseActiverecord::SchemaDumper.dump(ActiveRecord::Base.connection, current_schema)
+
+            expect(current_schema.string).to include('t.index "int1 * int2", name: "idx2", type: "set(10)", granularity: 4')
+            expect(current_schema.string).to include('t.index "date", name: "simple_idx", type: "minmax", granularity: 1')
           end
         end
       end

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -96,6 +96,26 @@ RSpec.describe 'Migration', :migrations do
         end
 
         context 'types' do
+          context 'integer' do
+            let(:directory) { 'dsl_table_with_integer_creation' }
+            it 'honors unsigned: false even when limit is omitted' do
+              subject
+
+              current_schema = schema(model)
+
+              expect(current_schema['default_int'].sql_type).to eq('Nullable(UInt32)')
+              expect(current_schema['signed_no_limit'].sql_type).to eq('Int32')
+              expect(current_schema['signed_no_limit'].default).to eq(-1)
+              expect(current_schema['signed_small'].sql_type).to eq('Int8')
+              expect(current_schema['signed_small'].default).to eq(-1)
+              expect(current_schema['signed_int32'].sql_type).to eq('Int32')
+              expect(current_schema['signed_int32'].default).to eq(-1)
+              expect(current_schema['signed_int64'].sql_type).to eq('Int64')
+              expect(current_schema['signed_int64'].default).to eq(-1)
+              expect(current_schema['unsigned_tiny'].sql_type).to eq('UInt8')
+            end
+          end
+
           context 'decimal' do
             let(:directory) { 'dsl_table_with_decimal_creation' }
             it 'creates a table with valid scale and precision' do

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -663,6 +663,133 @@ RSpec.describe 'Model', :migrations do
     end
   end
 
+  context 'map with float and bool' do
+    let!(:model) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = 'map_test'
+      end
+    end
+
+    before do
+      migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'add_map_float_bool')
+      quietly { ActiveRecord::MigrationContext.new(migrations_dir).up }
+    end
+
+    describe 'Float subtype support' do
+      it 'creates and retrieves Float32 map values' do
+        model.create!(
+          map_float32: {a: 1.5, b: 2.7, c: 3.14},
+          map_float64: {x: 1.0, y: 2.0},
+          map_bool: {flag: true},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_float32).to be_a Hash
+        expect(record.map_float32['a']).to eq(1.5)
+        expect(record.map_float32['b']).to eq(2.7)
+        expect(record.map_float32['c']).to eq(3.14)
+      end
+
+      it 'creates and retrieves Float64 map values' do
+        model.create!(
+          map_float32: {a: 1.0},
+          map_float64: {x: 123.456789, y: 987.654321},
+          map_bool: {flag: false},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_float64).to be_a Hash
+        expect(record.map_float64['x']).to eq(123.456789)
+        expect(record.map_float64['y']).to eq(987.654321)
+      end
+
+      it 'insert with insert_all' do
+        model.insert_all([{
+          map_float32: {a: 4.5},
+          map_float64: {x: 5.5},
+          map_bool: {flag: true},
+          date: date
+        }])
+
+        record = model.first
+        expect(record.map_float32['a']).to eq(4.5)
+        expect(record.map_float64['x']).to eq(5.5)
+      end
+
+      it 'retrieves float values without quoting in SQL' do
+        model.connection.insert("INSERT INTO #{model.table_name} (id, map_float32, map_float64, map_bool, date) VALUES (1, {'price': 99.99}, {'rate': 0.075}, {'active': true}, '2022-12-06')")
+
+        record = model.first
+        expect(record.map_float32['price']).to eq(99.99)
+        expect(record.map_float64['rate']).to eq(0.075)
+      end
+    end
+
+    describe 'Bool subtype support' do
+      it 'creates and retrieves Bool map values' do
+        model.create!(
+          map_float32: {a: 1.0},
+          map_float64: {x: 1.0},
+          map_bool: {enabled: true, active: false, verified: true},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_bool).to be_a Hash
+        expect(record.map_bool['enabled']).to eq(true)
+        expect(record.map_bool['active']).to eq(false)
+        expect(record.map_bool['verified']).to eq(true)
+      end
+
+      it 'handles boolean type casting' do
+        model.create!(
+          map_float32: {a: 1.0},
+          map_float64: {x: 1.0},
+          map_bool: {flag1: 1, flag2: 0, flag3: 'true', flag4: 'false'},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_bool['flag1']).to eq(true)
+        expect(record.map_bool['flag2']).to eq(false)
+        expect(record.map_bool['flag3']).to eq(true)
+        expect(record.map_bool['flag4']).to eq(false)
+      end
+
+      it 'retrieves bool values without quoting in SQL' do
+        model.connection.insert("INSERT INTO #{model.table_name} (id, map_float32, map_float64, map_bool, date) VALUES (1, {'a': 1.0}, {'x': 1.0}, {'is_active': true, 'is_deleted': false}, '2022-12-06')")
+
+        record = model.first
+        expect(record.map_bool['is_active']).to eq(true)
+        expect(record.map_bool['is_deleted']).to eq(false)
+      end
+    end
+
+    describe 'deserialize' do
+      it 'deserializes string float values from map_float32 type' do
+        type = model.type_for_attribute('map_float32')
+        expect(type.deserialize({'price' => '1.5', 'tax' => '0.25'})).to eq({'price' => 1.5, 'tax' => 0.25})
+      end
+
+      it 'deserializes string float values from map_float64 type' do
+        type = model.type_for_attribute('map_float64')
+        expect(type.deserialize({'rate' => '123.456789'})).to eq({'rate' => 123.456789})
+      end
+
+      it 'deserializes string bool values from map_bool type' do
+        type = model.type_for_attribute('map_bool')
+        expect(type.deserialize({'a' => 'true', 'b' => 'false', 'c' => '1', 'd' => '0'})).to eq({'a' => true, 'b' => false, 'c' => true, 'd' => false})
+      end
+
+      it 'deserializes integer bool values from map_bool type' do
+        type = model.type_for_attribute('map_bool')
+        expect(type.deserialize({'a' => 1, 'b' => 0})).to eq({'a' => true, 'b' => false})
+      end
+    end
+  end
+
   if Model.connection.server_version.to_f > 24.6
     context 'json' do
       let!(:json_model) do

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe 'Model', :migrations do
       let!(:record) { Model.create!(event_name: 'some event', date: Date.current, datetime: Time.now) }
 
       it 'finds the record' do
-        expect(Model.find_by(event_name: 'some event').attributes).to eq(record.attributes)
+        expect(Model.find_by(event_name: 'some event').attributes.except('ver')).to eq(record.attributes.except('ver'))
       end
 
       it 'find with record `insert into table`' do

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -661,6 +661,33 @@ RSpec.describe 'Model', :migrations do
         expect(record.map_array_datetime['c'][1]).to eq(DateTime.parse('2024-01-01 12:00:08'))
       end
     end
+
+    describe 'TimeZoneConverter compatibility' do
+      it 'does not crash when time_zone_aware_attributes is enabled' do
+        Time.use_zone('UTC') do
+          ActiveRecord::Base.time_zone_aware_attributes = true
+          model.reset_column_information
+
+          begin
+            model.create!(
+              map_datetime: {a: Time.now},
+              map_string: {a: 'test'},
+              map_int: {a: 1},
+              map_array_datetime: {a: []},
+              map_array_string: {a: []},
+              map_array_int: {a: []},
+              date: Date.today
+            )
+
+            expect { model.first.map_datetime }.to_not raise_error
+            expect(model.first.map_datetime['a']).to be_a DateTime
+          ensure
+            ActiveRecord::Base.time_zone_aware_attributes = false
+            model.reset_column_information
+          end
+        end
+      end
+    end
   end
 
   context 'map with float and bool' do

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe 'Model', :migrations do
       let!(:record) { Model.create!(event_name: 'some event', date: Date.current, datetime: Time.now) }
 
       it 'finds the record' do
-        expect(Model.find_by(event_name: 'some event').attributes).to eq(record.attributes)
+        expect(Model.find_by(event_name: 'some event').attributes.except('ver')).to eq(record.attributes.except('ver'))
       end
 
       it 'find with record `insert into table`' do
@@ -659,6 +659,182 @@ RSpec.describe 'Model', :migrations do
         expect(record.map_array_datetime['c']).to be_a Array
         expect(record.map_array_datetime['c'][0]).to eq(DateTime.parse('2022-12-05 15:22:49'))
         expect(record.map_array_datetime['c'][1]).to eq(DateTime.parse('2024-01-01 12:00:08'))
+      end
+
+      it 'handles already deserialized DateTime/Time map values without re-parsing' do
+        now = Time.now
+        instance = model.instantiate({
+          'id' => '1',
+          'map_datetime' => {'t1' => now, 't2' => DateTime.now},
+          'map_date' => {'d' => Date.current},
+          'map_string' => {'x' => 'test'},
+          'map_int' => {'n' => 1},
+          'map_array_datetime' => {'a' => []},
+          'map_array_string' => {'a' => []},
+          'map_array_int' => {'a' => []},
+          'date' => Date.today
+        })
+
+        expect { instance.map_datetime }.to_not raise_error
+        expect(instance.map_datetime['t1']).to be_a(Time).or be_a(DateTime)
+        expect(instance.map_datetime['t2']).to be_a DateTime
+
+        expect { instance.map_date }.to_not raise_error
+        expect(instance.map_date['d']).to be_a Date
+      end
+    end
+
+    describe 'TimeZoneConverter compatibility' do
+      it 'does not crash when time_zone_aware_attributes is enabled' do
+        Time.use_zone('UTC') do
+          ActiveRecord::Base.time_zone_aware_attributes = true
+          model.reset_column_information
+
+          begin
+            model.create!(
+              map_datetime: {a: Time.now},
+              map_string: {a: 'test'},
+              map_int: {a: 1},
+              map_array_datetime: {a: []},
+              map_array_string: {a: []},
+              map_array_int: {a: []},
+              date: Date.today
+            )
+
+            expect { model.first.map_datetime }.to_not raise_error
+            expect(model.first.map_datetime['a']).to be_a DateTime
+          ensure
+            ActiveRecord::Base.time_zone_aware_attributes = false
+            model.reset_column_information
+          end
+        end
+      end
+    end
+  end
+
+  context 'map with float and bool' do
+    let!(:model) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = 'map_test'
+      end
+    end
+
+    before do
+      migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'add_map_float_bool')
+      quietly { ActiveRecord::MigrationContext.new(migrations_dir).up }
+    end
+
+    describe 'Float subtype support' do
+      it 'creates and retrieves Float32 map values' do
+        model.create!(
+          map_float32: {a: 1.5, b: 2.7, c: 3.14},
+          map_float64: {x: 1.0, y: 2.0},
+          map_bool: {flag: true},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_float32).to be_a Hash
+        expect(record.map_float32['a']).to eq(1.5)
+        expect(record.map_float32['b']).to eq(2.7)
+        expect(record.map_float32['c']).to eq(3.14)
+      end
+
+      it 'creates and retrieves Float64 map values' do
+        model.create!(
+          map_float32: {a: 1.0},
+          map_float64: {x: 123.456789, y: 987.654321},
+          map_bool: {flag: false},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_float64).to be_a Hash
+        expect(record.map_float64['x']).to eq(123.456789)
+        expect(record.map_float64['y']).to eq(987.654321)
+      end
+
+      it 'insert with insert_all' do
+        model.insert_all([{
+          map_float32: {a: 4.5},
+          map_float64: {x: 5.5},
+          map_bool: {flag: true},
+          date: date
+        }])
+
+        record = model.first
+        expect(record.map_float32['a']).to eq(4.5)
+        expect(record.map_float64['x']).to eq(5.5)
+      end
+
+      it 'retrieves float values without quoting in SQL' do
+        model.connection.insert("INSERT INTO #{model.table_name} (id, map_float32, map_float64, map_bool, date) VALUES (1, {'price': 99.99}, {'rate': 0.075}, {'active': true}, '2022-12-06')")
+
+        record = model.first
+        expect(record.map_float32['price']).to eq(99.99)
+        expect(record.map_float64['rate']).to eq(0.075)
+      end
+    end
+
+    describe 'Bool subtype support' do
+      it 'creates and retrieves Bool map values' do
+        model.create!(
+          map_float32: {a: 1.0},
+          map_float64: {x: 1.0},
+          map_bool: {enabled: true, active: false, verified: true},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_bool).to be_a Hash
+        expect(record.map_bool['enabled']).to eq(true)
+        expect(record.map_bool['active']).to eq(false)
+        expect(record.map_bool['verified']).to eq(true)
+      end
+
+      it 'handles boolean type casting' do
+        model.create!(
+          map_float32: {a: 1.0},
+          map_float64: {x: 1.0},
+          map_bool: {flag1: 1, flag2: 0, flag3: 'true', flag4: 'false'},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_bool['flag1']).to eq(true)
+        expect(record.map_bool['flag2']).to eq(false)
+        expect(record.map_bool['flag3']).to eq(true)
+        expect(record.map_bool['flag4']).to eq(false)
+      end
+
+      it 'retrieves bool values without quoting in SQL' do
+        model.connection.insert("INSERT INTO #{model.table_name} (id, map_float32, map_float64, map_bool, date) VALUES (1, {'a': 1.0}, {'x': 1.0}, {'is_active': true, 'is_deleted': false}, '2022-12-06')")
+
+        record = model.first
+        expect(record.map_bool['is_active']).to eq(true)
+        expect(record.map_bool['is_deleted']).to eq(false)
+      end
+    end
+
+    describe 'deserialize' do
+      it 'deserializes string float values from map_float32 type' do
+        type = model.type_for_attribute('map_float32')
+        expect(type.deserialize({'price' => '1.5', 'tax' => '0.25'})).to eq({'price' => 1.5, 'tax' => 0.25})
+      end
+
+      it 'deserializes string float values from map_float64 type' do
+        type = model.type_for_attribute('map_float64')
+        expect(type.deserialize({'rate' => '123.456789'})).to eq({'rate' => 123.456789})
+      end
+
+      it 'deserializes string bool values from map_bool type' do
+        type = model.type_for_attribute('map_bool')
+        expect(type.deserialize({'a' => 'true', 'b' => 'false', 'c' => '1', 'd' => '0'})).to eq({'a' => true, 'b' => false, 'c' => true, 'd' => false})
+      end
+
+      it 'deserializes integer bool values from map_bool type' do
+        type = model.type_for_attribute('map_bool')
+        expect(type.deserialize({'a' => 1, 'b' => 0})).to eq({'a' => true, 'b' => false})
       end
     end
   end

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe 'Model', :migrations do
       let!(:record) { Model.create!(event_name: 'some event', date: Date.current, datetime: Time.now) }
 
       it 'finds the record' do
-        expect(Model.find_by(event_name: 'some event').attributes).to eq(record.attributes)
+        expect(Model.find_by(event_name: 'some event').attributes.except('ver')).to eq(record.attributes.except('ver'))
       end
 
       it 'find with record `insert into table`' do
@@ -705,6 +705,182 @@ RSpec.describe 'Model', :migrations do
         expect(record.map_array_datetime['c']).to be_a Array
         expect(record.map_array_datetime['c'][0]).to eq(DateTime.parse('2022-12-05 15:22:49'))
         expect(record.map_array_datetime['c'][1]).to eq(DateTime.parse('2024-01-01 12:00:08'))
+      end
+
+      it 'handles already deserialized DateTime/Time map values without re-parsing' do
+        now = Time.now
+        instance = model.instantiate({
+          'id' => '1',
+          'map_datetime' => {'t1' => now, 't2' => DateTime.now},
+          'map_date' => {'d' => Date.current},
+          'map_string' => {'x' => 'test'},
+          'map_int' => {'n' => 1},
+          'map_array_datetime' => {'a' => []},
+          'map_array_string' => {'a' => []},
+          'map_array_int' => {'a' => []},
+          'date' => Date.today
+        })
+
+        expect { instance.map_datetime }.to_not raise_error
+        expect(instance.map_datetime['t1']).to be_a(Time).or be_a(DateTime)
+        expect(instance.map_datetime['t2']).to be_a DateTime
+
+        expect { instance.map_date }.to_not raise_error
+        expect(instance.map_date['d']).to be_a Date
+      end
+    end
+
+    describe 'TimeZoneConverter compatibility' do
+      it 'does not crash when time_zone_aware_attributes is enabled' do
+        Time.use_zone('UTC') do
+          ActiveRecord::Base.time_zone_aware_attributes = true
+          model.reset_column_information
+
+          begin
+            model.create!(
+              map_datetime: {a: Time.now},
+              map_string: {a: 'test'},
+              map_int: {a: 1},
+              map_array_datetime: {a: []},
+              map_array_string: {a: []},
+              map_array_int: {a: []},
+              date: Date.today
+            )
+
+            expect { model.first.map_datetime }.to_not raise_error
+            expect(model.first.map_datetime['a']).to be_a DateTime
+          ensure
+            ActiveRecord::Base.time_zone_aware_attributes = false
+            model.reset_column_information
+          end
+        end
+      end
+    end
+  end
+
+  context 'map with float and bool' do
+    let!(:model) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = 'map_test'
+      end
+    end
+
+    before do
+      migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'add_map_float_bool')
+      quietly { ActiveRecord::MigrationContext.new(migrations_dir).up }
+    end
+
+    describe 'Float subtype support' do
+      it 'creates and retrieves Float32 map values' do
+        model.create!(
+          map_float32: {a: 1.5, b: 2.7, c: 3.14},
+          map_float64: {x: 1.0, y: 2.0},
+          map_bool: {flag: true},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_float32).to be_a Hash
+        expect(record.map_float32['a']).to eq(1.5)
+        expect(record.map_float32['b']).to eq(2.7)
+        expect(record.map_float32['c']).to eq(3.14)
+      end
+
+      it 'creates and retrieves Float64 map values' do
+        model.create!(
+          map_float32: {a: 1.0},
+          map_float64: {x: 123.456789, y: 987.654321},
+          map_bool: {flag: false},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_float64).to be_a Hash
+        expect(record.map_float64['x']).to eq(123.456789)
+        expect(record.map_float64['y']).to eq(987.654321)
+      end
+
+      it 'insert with insert_all' do
+        model.insert_all([{
+          map_float32: {a: 4.5},
+          map_float64: {x: 5.5},
+          map_bool: {flag: true},
+          date: date
+        }])
+
+        record = model.first
+        expect(record.map_float32['a']).to eq(4.5)
+        expect(record.map_float64['x']).to eq(5.5)
+      end
+
+      it 'retrieves float values without quoting in SQL' do
+        model.connection.insert("INSERT INTO #{model.table_name} (id, map_float32, map_float64, map_bool, date) VALUES (1, {'price': 99.99}, {'rate': 0.075}, {'active': true}, '2022-12-06')")
+
+        record = model.first
+        expect(record.map_float32['price']).to eq(99.99)
+        expect(record.map_float64['rate']).to eq(0.075)
+      end
+    end
+
+    describe 'Bool subtype support' do
+      it 'creates and retrieves Bool map values' do
+        model.create!(
+          map_float32: {a: 1.0},
+          map_float64: {x: 1.0},
+          map_bool: {enabled: true, active: false, verified: true},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_bool).to be_a Hash
+        expect(record.map_bool['enabled']).to eq(true)
+        expect(record.map_bool['active']).to eq(false)
+        expect(record.map_bool['verified']).to eq(true)
+      end
+
+      it 'handles boolean type casting' do
+        model.create!(
+          map_float32: {a: 1.0},
+          map_float64: {x: 1.0},
+          map_bool: {flag1: 1, flag2: 0, flag3: 'true', flag4: 'false'},
+          date: date
+        )
+
+        record = model.first
+        expect(record.map_bool['flag1']).to eq(true)
+        expect(record.map_bool['flag2']).to eq(false)
+        expect(record.map_bool['flag3']).to eq(true)
+        expect(record.map_bool['flag4']).to eq(false)
+      end
+
+      it 'retrieves bool values without quoting in SQL' do
+        model.connection.insert("INSERT INTO #{model.table_name} (id, map_float32, map_float64, map_bool, date) VALUES (1, {'a': 1.0}, {'x': 1.0}, {'is_active': true, 'is_deleted': false}, '2022-12-06')")
+
+        record = model.first
+        expect(record.map_bool['is_active']).to eq(true)
+        expect(record.map_bool['is_deleted']).to eq(false)
+      end
+    end
+
+    describe 'deserialize' do
+      it 'deserializes string float values from map_float32 type' do
+        type = model.type_for_attribute('map_float32')
+        expect(type.deserialize({'price' => '1.5', 'tax' => '0.25'})).to eq({'price' => 1.5, 'tax' => 0.25})
+      end
+
+      it 'deserializes string float values from map_float64 type' do
+        type = model.type_for_attribute('map_float64')
+        expect(type.deserialize({'rate' => '123.456789'})).to eq({'rate' => 123.456789})
+      end
+
+      it 'deserializes string bool values from map_bool type' do
+        type = model.type_for_attribute('map_bool')
+        expect(type.deserialize({'a' => 'true', 'b' => 'false', 'c' => '1', 'd' => '0'})).to eq({'a' => true, 'b' => false, 'c' => true, 'd' => false})
+      end
+
+      it 'deserializes integer bool values from map_bool type' do
+        type = model.type_for_attribute('map_bool')
+        expect(type.deserialize({'a' => 1, 'b' => 0})).to eq({'a' => true, 'b' => false})
       end
     end
   end

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -660,6 +660,28 @@ RSpec.describe 'Model', :migrations do
         expect(record.map_array_datetime['c'][0]).to eq(DateTime.parse('2022-12-05 15:22:49'))
         expect(record.map_array_datetime['c'][1]).to eq(DateTime.parse('2024-01-01 12:00:08'))
       end
+
+      it 'handles already deserialized DateTime/Time map values without re-parsing' do
+        now = Time.now
+        instance = model.instantiate({
+          'id' => '1',
+          'map_datetime' => {'t1' => now, 't2' => DateTime.now},
+          'map_date' => {'d' => Date.current},
+          'map_string' => {'x' => 'test'},
+          'map_int' => {'n' => 1},
+          'map_array_datetime' => {'a' => []},
+          'map_array_string' => {'a' => []},
+          'map_array_int' => {'a' => []},
+          'date' => Date.today
+        })
+
+        expect { instance.map_datetime }.to_not raise_error
+        expect(instance.map_datetime['t1']).to be_a(Time).or be_a(DateTime)
+        expect(instance.map_datetime['t2']).to be_a DateTime
+
+        expect { instance.map_date }.to_not raise_error
+        expect(instance.map_date['d']).to be_a Date
+      end
     end
 
     describe 'TimeZoneConverter compatibility' do

--- a/spec/single/response_format_thread_safety_spec.rb
+++ b/spec/single/response_format_thread_safety_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Regression coverage for the @response_format thread-safety race.
+#
+# `with_response_format` mutates an instance variable on the adapter to scope
+# the response format for the duration of a block. When the same adapter is
+# shared across threads — as happens in Capybara system specs where the test
+# thread and the Puma server thread both check out the same connection — one
+# thread's block can leak its format into another thread's `execute` call,
+# returning the raw response body instead of a parsed Hash.
+RSpec.describe 'ActiveRecord::ConnectionAdapters::Clickhouse::SchemaStatements response format thread safety' do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:default_format) { ActiveRecord::ConnectionAdapters::ClickhouseAdapter::DEFAULT_RESPONSE_FORMAT }
+
+  before do
+    connection.execute('CREATE TABLE response_format_thread_test (id UInt64) ENGINE = MergeTree ORDER BY id')
+  end
+
+  after do
+    connection.execute('DROP TABLE IF EXISTS response_format_thread_test')
+  end
+
+  it '#execute on one thread is not affected by with_response_format(nil) on another thread' do
+    inside_block = Queue.new
+    release = Queue.new
+
+    holder = Thread.new do
+      connection.with_response_format(nil) do
+        inside_block << true
+        release.pop
+      end
+    end
+
+    inside_block.pop
+
+    begin
+      result = connection.execute('SELECT count() AS c FROM response_format_thread_test')
+
+      expect(result).to be_a(Hash), "expected parsed Hash from default format, got #{result.class}: #{result.inspect[0..200]}"
+      expect(result['data']).to be_a(Array)
+    ensure
+      release << true
+      holder.join
+    end
+  end
+
+  it 'with_response_format nests correctly within a single thread' do
+    expect(connection.execute('SELECT 1 AS x')).to be_a(Hash)
+
+    connection.with_response_format(nil) do
+      expect(connection.execute('SELECT 1 AS x')).to be_a(String)
+
+      connection.with_response_format('JSONCompact') do
+        expect(connection.execute('SELECT 1 AS x')).to be_a(Hash)
+      end
+
+      expect(connection.execute('SELECT 1 AS x')).to be_a(String)
+    end
+
+    expect(connection.execute('SELECT 1 AS x')).to be_a(Hash)
+  end
+end

--- a/spec/single/to_sql_visitor_spec.rb
+++ b/spec/single/to_sql_visitor_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe 'ToSql visitor', :migrations do
+  let(:model) do
+    Class.new(ActiveRecord::Base) do
+      self.table_name = 'events'
+    end
+  end
+
+  before do
+    migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'mat_view')
+    quietly { ActiveRecord::MigrationContext.new(migrations_dir, model.connection.schema_migration).up }
+  end
+
+  context 'when given a basic query' do
+    it 'generates the correct SQL' do
+      sql_trap = SqlCapture.new { model.select(:id).where(date: '2021-09-22').limit(10).load }
+      expect(sql_trap.captured).to eq("SELECT events.id FROM events WHERE events.date = '2021-09-22' LIMIT 10")
+    end
+  end
+
+  context 'when given an aggregation query' do
+    it 'generates the correct SQL' do
+      sql_trap = SqlCapture.new { model.where(date: '2021-09-22').count }
+      expect(sql_trap.captured).to eq("SELECT COUNT(*) FROM events WHERE events.date = '2021-09-22'")
+    end
+
+    context 'when the expression to be aggregated is not the wildcard (*)' do
+      it 'generates the correct SQL' do
+        sql_trap = SqlCapture.new { model.select(:id).where(date: '2021-09-22').count }
+        expect(sql_trap.captured).to eq("SELECT COUNT(events.id) FROM events WHERE events.date = '2021-09-22'")
+      end
+
+      context 'when the expression is an Arel node' do
+        it 'generates the correct SQL' do
+          sql_trap = SqlCapture.new { model.select(model.arel_table[:date]).where(date: '2021-09-22').count }
+          expect(sql_trap.captured).to eq("SELECT COUNT(events.date) FROM events WHERE events.date = '2021-09-22'")
+        end
+
+        context 'when the relation is a Clickhouse view' do
+          let(:mat_view_model) do
+            Class.new(ActiveRecord::Base) do
+              self.is_view = true
+              self.table_name = 'event_dates'
+            end
+          end
+
+          it 'generates the correct SQL (by suffixing the aggregate function name!)' do
+            sql_trap = SqlCapture.new { mat_view_model.where(date: '2021-09-22').sum(:ids) }
+            expect(sql_trap.captured).to eq("SELECT sumMerge(event_dates.ids) FROM event_dates WHERE event_dates.date = '2021-09-22'")
+          end
+        end
+      end
+    end
+  end
+
+  context 'when given a query with inline settings' do
+    it 'passes the settings into the SQL' do
+      sql = model.settings(max_insert_block_size: 10, use_skip_indexes: true).to_sql
+      expect(sql).to eq("SELECT events.* FROM events SETTINGS max_insert_block_size = 10, use_skip_indexes = TRUE")
+    end
+
+    it 'sanitizes non-word characters in setting names' do
+      sql = model.settings('max_ insert_block_ size:' => 10, 'use_skip_indexes!' => true).to_sql
+      expect(sql).to eq("SELECT events.* FROM events SETTINGS max_insert_block_size = 10, use_skip_indexes = TRUE")
+    end
+
+    it 'permits arbitrary setting names if given as SqlLiterals (!)' do
+      sql = model.settings(Arel.sql('max_ insert_block_ size:') => 10, Arel.sql('use_skip_indexes!') => true).to_sql
+      expect(sql).to eq("SELECT events.* FROM events SETTINGS max_ insert_block_ size: = 10, use_skip_indexes! = TRUE")
+    end
+
+    it 'quotes setting values' do
+      sql = model.settings(insert_deduplication_token: :foo_bar_123).to_sql
+      expect(sql).to eq("SELECT events.* FROM events SETTINGS insert_deduplication_token = 'foo_bar_123'")
+    end
+
+    it 'allows passing the symbol :default to reset a setting' do
+      sql = model.settings(max_insert_block_size: :default).to_sql
+      expect(sql).to eq("SELECT events.* FROM events SETTINGS max_insert_block_size = DEFAULT")
+    end
+  end
+end

--- a/spec/single/url_config_spec.rb
+++ b/spec/single/url_config_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+RSpec.describe 'URL-based configuration' do
+  let(:http_connection) { instance_double(Net::HTTP) }
+  let(:response) { instance_double(Net::HTTPResponse, code: '200', body: '') }
+
+  before do
+    allow(Net::HTTP).to receive(:start).and_return(http_connection)
+    allow(http_connection).to receive(:keep_alive_timeout=)
+    allow(http_connection).to receive(:started?).and_return(true)
+    allow(http_connection).to receive(:post).and_return(response)
+  end
+
+  def net_http_start_args
+    args = nil
+    allow(Net::HTTP).to receive(:start) do |*a, **kw, &block|
+      args = { args: a, kwargs: kw }
+      block.call(http_connection) if block
+      http_connection
+    end
+    ActiveRecord::Base.clickhouse_connection(config)
+    args
+  end
+
+  context 'basic URL' do
+    let(:config) { { url: 'clickhouse://app_user:secret@db.example.com:9000/mydb' } }
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'sets host from URL' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:host]).to eq('db.example.com')
+    end
+
+    it 'sets port from URL' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:port]).to eq(9000)
+    end
+
+    it 'sets username from URL' do
+      expect(adapter.instance_variable_get(:@connection_config)[:user]).to eq('app_user')
+    end
+
+    it 'sets password from URL' do
+      expect(adapter.instance_variable_get(:@connection_config)[:password]).to eq('secret')
+    end
+
+    it 'sets database from URL path' do
+      expect(adapter.instance_variable_get(:@connection_config)[:database]).to eq('mydb')
+    end
+  end
+
+  context 'URL with special characters in credentials' do
+    let(:config) { { url: 'clickhouse://us%40er:p%40ss%3Aword@localhost:8123/testdb' } }
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'decodes username' do
+      expect(adapter.instance_variable_get(:@connection_config)[:user]).to eq('us@er')
+    end
+
+    it 'decodes password' do
+      expect(adapter.instance_variable_get(:@connection_config)[:password]).to eq('p@ss:word')
+    end
+  end
+
+  context 'URL with query parameters' do
+    let(:config) { { url: 'clickhouse://user:pass@localhost:8123/db?ssl=true&debug=true&read_timeout=120&write_timeout=90&keep_alive_timeout=30&http_auth=basic&cluster_name=mycluster' } }
+
+    before do
+      allow(http_connection).to receive(:read_timeout=)
+      allow(http_connection).to receive(:write_timeout=)
+    end
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'sets ssl from query params' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:ssl]).to eq(true)
+    end
+
+    it 'sets debug from query params' do
+      expect(adapter.instance_variable_get(:@debug)).to eq(true)
+    end
+
+    it 'sets read_timeout from query params' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:read_timeout]).to eq(120)
+    end
+
+    it 'sets write_timeout from query params' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:write_timeout]).to eq(90)
+    end
+
+    it 'sets keep_alive_timeout from query params' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:keep_alive_timeout]).to eq(30)
+    end
+
+    it 'sets http_auth from query params' do
+      expect(adapter.instance_variable_get(:@http_auth)).to eq(:basic)
+    end
+  end
+
+  context 'explicit config keys override URL values' do
+    let(:config) do
+      {
+        url: 'clickhouse://url_user:url_pass@url_host:9000/url_db',
+        host: 'override_host',
+        database: 'override_db',
+        username: 'override_user'
+      }
+    end
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'uses explicit host over URL host' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:host]).to eq('override_host')
+    end
+
+    it 'uses explicit database over URL database' do
+      expect(adapter.instance_variable_get(:@connection_config)[:database]).to eq('override_db')
+    end
+
+    it 'uses explicit username over URL username' do
+      expect(adapter.instance_variable_get(:@connection_config)[:user]).to eq('override_user')
+    end
+
+    it 'keeps URL password when not overridden' do
+      expect(adapter.instance_variable_get(:@connection_config)[:password]).to eq('url_pass')
+    end
+  end
+
+  context 'URL without port' do
+    let(:config) { { url: 'clickhouse://localhost/mydb' } }
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'uses default port 8123' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:port]).to eq(8123)
+    end
+  end
+
+  context 'URL without database' do
+    let(:config) { { url: 'clickhouse://localhost:8123' } }
+
+    it 'raises ArgumentError about missing database' do
+      expect { ActiveRecord::Base.clickhouse_connection(config) }
+        .to raise_error(ArgumentError, /No database specified/)
+    end
+  end
+
+  context 'URL with invalid http_auth' do
+    let(:config) { { url: 'clickhouse://localhost:8123/db?http_auth=invalid_mode' } }
+
+    it 'raises ArgumentError about unknown http_auth mode' do
+      expect { ActiveRecord::Base.clickhouse_connection(config) }
+        .to raise_error(ArgumentError, /Unknown :http_auth mode/)
+    end
+  end
+
+  context 'backward compatibility without url key' do
+    let(:config) do
+      {
+        adapter: 'clickhouse',
+        host: 'localhost',
+        port: 8123,
+        database: 'test_db',
+        username: 'user',
+        password: 'pass'
+      }
+    end
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'still works with explicit hash config' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:host]).to eq('localhost')
+      expect(adapter.instance_variable_get(:@connection_config)[:database]).to eq('test_db')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'bundler/setup'
 require 'active_record'
 require 'clickhouse-activerecord'
+require 'active_support/notifications'
 require 'active_support/testing/stream'
 
 ClickhouseActiverecord.load
@@ -30,17 +31,21 @@ RSpec.configure do |config|
 
     clear_consts
     clear_db
+    ActiveRecord::Base.connection.schema_cache.clear!
   end
+
+  config.filter_run_excluding cluster: !ENV.key?('CLICKHOUSE_CLUSTER')
 end
 
 ActiveRecord::Base.configurations = HashWithIndifferentAccess.new(
   default: {
     adapter: 'clickhouse',
     host: 'localhost',
-    port: ENV['CLICKHOUSE_PORT'] || 8123,
-    database: ENV['CLICKHOUSE_DATABASE'] || 'test',
+    port: ENV.fetch('CLICKHOUSE_PORT', 8123),
+    database: ENV.fetch('CLICKHOUSE_DATABASE', 'test'),
     username: ENV['CLICKHOUSE_USER'],
     password: ENV['CLICKHOUSE_PASSWORD'],
+    use_metadata_table: !ENV['CLICKHOUSE_CLUSTER'],
     cluster_name: ENV['CLICKHOUSE_CLUSTER'],
   }
 )
@@ -69,5 +74,23 @@ def clear_consts
 
     Object.send(:remove_const, const.to_s) if const
     $LOADED_FEATURES.delete(file)
+  end
+end
+
+class SqlCapture
+  def initialize(&block)
+    @block = block
+  end
+
+  def captured
+    trap = ->(_name, _started, _finished, _unique_id, payload) { store_captured(payload[:sql]) }
+    ActiveSupport::Notifications.subscribed(trap, 'sql.active_record') { @block.call }
+    @captured
+  end
+
+  private
+
+  def store_captured(sql)
+    @captured = sql
   end
 end


### PR DESCRIPTION
## Summary

Brings the upstream-sync work that landed on `master` (PR #42) into the long-lived `huntress_mods_8-0` branch via a **merge** (not a rebase — see note below).

Upstream changes pulled in:
- Map OID fixes — Float/Bool subtypes (#237), TimeZoneConverter crash (#238), already-parsed Date/DateTime guard (#239)
- URL-based configuration (#249)
- Configurable HTTP auth modes (#240)
- Parse column `DEFAULT` kinds (#246)
- Schema-dump fix for multi-column index expressions (#234)
- Rails 8 compatibility fixes (#245), `unsigned: false` honoring (#253), `@response_format` thread-safety (#251)

## Conflict resolutions

The two branches had overlapping work in the schema-dumper / column / OID areas. Resolutions:

- **`column.rb` / `schema_statements.rb`** — Adopt upstream's unified `default_kind` (`none`/`default`/`materialized`/`alias`/`ephemeral`) as the source of truth and redefine Huntress's `materialized?` in terms of it, so the MATERIALIZED schema-dump round-trip (#41) keeps working. Preserved Huntress's special-casing that rides a `MATERIALIZED` expression through `default_function` (so non-function expressions like `MATERIALIZED a + 1` round-trip). Use upstream's `DescribedColumn` object interface in `new_column_from_field`. Column equality now compares `codec` + `default_kind`.
- **`oid/map.rb`** — Keep both Huntress's `extract_map_value_type` (paren-depth parser) and upstream's `already_deserialized?` guard (#239); both are called by the merged deserialize path.
- **`schema_dumper.rb`** — Keep Huntress's projection-aware index block and adopt upstream's improved index regex (`INDEX \S+ .+? TYPE`) that handles multi-column expressions (#234).
- **`column_spec.rb`** — Migrated two Huntress unit tests off the removed `materialized:` constructor kwarg to `default_kind:`.
- **`CHANGELOG.md`** — Kept both the Unreleased `joins_final` entry and the `1.6.7` entry.

The adapter, Arel visitor, and `model_spec.rb` auto-merged cleanly (both `joins_final` and upstream work retained).

## Tests

Full single-server suite green against ClickHouse 25.10 locally: **231 examples, 0 failures** (Huntress specs + upstream specs + `joins_final` specs together).

## Why a merge instead of a rebase

`huntress_mods_8-0` is a long-lived shared branch. Rebasing it onto master would rewrite published history (force-push, disrupting anything based on it) and was conflict-heavy (~36 commits replayed, conflicting from commit 3). A merge resolves the overlap once, preserves history, and is reviewable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeQx7AkCPiyk5yqj7m3koX)_