### PR TITLE
Add left_joins_final (LEFT OUTER JOIN ... FINAL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Add `joins_final` to apply the `FINAL` modifier to joined tables (`INNER JOIN <table> FINAL ON ...`), not just the primary `FROM` table
+* Add `left_joins_final`, the `LEFT OUTER JOIN <table> FINAL ON ...` counterpart of `joins_final`, for FINAL-merged optional joins
 
 ### Version 1.6.6 (Feb 16, 2026)
 

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -54,6 +54,7 @@ module ActiveRecord
     module ClassMethods
       delegate :final, :final!,
                :joins_final, :joins_final!,
+               :left_joins_final, :left_joins_final!,
                :group_by_grouping_sets, :group_by_grouping_sets!,
                :settings, :settings!,
                :window, :window!,

--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -120,6 +120,36 @@ module CoreExtensions
         self
       end
 
+      # Like #joins_final, but adds the join(s) as LEFT OUTER JOINs (via
+      # #left_outer_joins) and renders FINAL on the joined table. Use this when
+      # the joined rows must be preserved even with no match (e.g. an optional
+      # catalog lookup) while still merging the joined table with FINAL.
+      # For example:
+      #
+      #   AppControlEvent.left_joins_final(:espm_binary)
+      #   # SELECT ... FROM espm_app_control_events
+      #   #   LEFT OUTER JOIN espm_binaries FINAL ON ...
+      #
+      # Each argument is an association name and is added as a left outer join
+      # (like #left_outer_joins); FINAL is then rendered on the joined table.
+      # Joins are matched by table name, so if the same table is joined more
+      # than once every join of that table receives FINAL. An
+      # <tt>ActiveRecord::ActiveRecordError</tt> will be raised if the database
+      # is not ClickHouse.
+      #
+      # @param [Array] args
+      def left_joins_final(*args)
+        spawn.left_joins_final!(*args)
+      end
+
+      # @param [Array] args
+      def left_joins_final!(*args)
+        check_command!('FINAL')
+        left_outer_joins!(*args)
+        self.joins_final_values |= args
+        self
+      end
+
       def joins_final_values
         @values.fetch(:joins_final, ::ActiveRecord::QueryMethods::FROZEN_EMPTY_ARRAY)
       end

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -507,6 +507,14 @@ RSpec.describe 'Model', :migrations do
         expect(Model.left_joins_final(:joins)).to be_a(ActiveRecord::Relation)
       end
 
+      it 'collapses to a single FINAL join when the same association is also added via #joins_final' do
+        # ActiveRecord deduplicates an association present in both joins and
+        # left_outer_joins into one INNER JOIN (INNER wins), and the shared
+        # joins_final_values store dedups via |=, so FINAL is applied once.
+        sql = Model.joins_final(:joins).left_joins_final(:joins).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample INNER JOIN joins FINAL ON joins.model_id = sample.event_name')
+      end
+
       it 'executes against ClickHouse and merges the FINAL-joined table' do
         Model.create!(date: date, event_name: 'left-final-join')
         Model.create!(date: date, event_name: 'left-final-join')

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -471,6 +471,55 @@ RSpec.describe 'Model', :migrations do
       end
     end
 
+    describe '#left_joins_final' do
+      it 'adds FINAL to a LEFT OUTER joined table' do
+        sql = Model.left_joins_final(:joins).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample LEFT OUTER JOIN joins FINAL ON joins.model_id = sample.event_name')
+      end
+
+      it 'applies FINAL to both the FROM table and the left join when combined with #final' do
+        sql = Model.final.left_joins_final(:joins).where(date: '2023-07-21').to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample FINAL LEFT OUTER JOIN joins FINAL ON joins.model_id = sample.event_name WHERE sample.date = \'2023-07-21\'')
+      end
+
+      it 'does not duplicate a join already added via #left_outer_joins' do
+        sql = Model.left_outer_joins(:joins).left_joins_final(:joins).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample LEFT OUTER JOIN joins FINAL ON joins.model_id = sample.event_name')
+      end
+
+      it 'does not add FINAL to the FROM table on its own' do
+        sql = Model.left_joins_final(:joins).to_sql
+        expect(sql).not_to match(/FROM sample FINAL/)
+      end
+
+      it 'keeps the join LEFT OUTER (does not promote to INNER)' do
+        sql = Model.left_joins_final(:joins).to_sql
+        expect(sql).to include('LEFT OUTER JOIN joins FINAL')
+        expect(sql).not_to match(/INNER JOIN joins/)
+      end
+
+      it 'can be removed with unscope, keeping the plain left join' do
+        sql = Model.left_joins_final(:joins).unscope(:joins_final).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample LEFT OUTER JOIN joins ON joins.model_id = sample.event_name')
+      end
+
+      it 'is chainable (returns a relation)' do
+        expect(Model.left_joins_final(:joins)).to be_a(ActiveRecord::Relation)
+      end
+
+      it 'executes against ClickHouse and merges the FINAL-joined table' do
+        Model.create!(date: date, event_name: 'left-final-join')
+        Model.create!(date: date, event_name: 'left-final-join')
+
+        relation = Model.final.left_joins_final(:twins).where(sample: { event_name: 'left-final-join' })
+        expect(relation.to_sql).to include('LEFT OUTER JOIN').and include('FINAL ON')
+        # The sample table is a ReplacingMergeTree: FINAL dedups the two rows to
+        # one on both the FROM side and the self-joined side, so the join
+        # produces a single row.
+        expect(relation.count).to eq(1)
+      end
+    end
+
     describe '#limit_by' do
       it 'works' do
         sql = Model.limit_by(1, :event_name).to_sql


### PR DESCRIPTION
## What

Adds `left_joins_final` / `left_joins_final!`, the `LEFT OUTER JOIN <table> FINAL ON ...` counterpart to the existing `joins_final`.

`joins_final` only emits `INNER JOIN <table> FINAL`. `left_joins_final` adds the association via `left_outer_joins` and renders `FINAL` on the joined table, for optional/catalog joins whose rows must be preserved when there is no match — while still merging the joined table with `FINAL`.

It shares `joins_final_values`, so the existing final-join marking and `unscope(:joins_final)` handling apply unchanged.

```ruby
AppControlEvent.left_joins_final(:espm_binary)
# SELECT ... FROM espm_app_control_events
#   LEFT OUTER JOIN espm_binaries FINAL ON ...
```

## Changes

- `lib/core_extensions/active_record/relation.rb` — new `left_joins_final` / `left_joins_final!`
- `lib/active_record/connection_adapters/clickhouse_adapter.rb` — delegate the new methods
- `CHANGELOG.md` — Unreleased entry
- `spec/single/model_spec.rb` — `#left_joins_final` spec block (SQL shape, `final` combination, dedup, unscope, LEFT-not-INNER, ClickHouse execution test)

## Testing

The specs were not run in the authoring environment (the execution test needs a live ClickHouse instance). The code mirrors the existing `joins_final` implementation and the SQL-shape assertions are deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014uhz69nyLNfuciaTh8UhSa)_