### PR TITLE
Detect Array columns via Column#array

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/column.rb
+++ b/lib/active_record/connection_adapters/clickhouse/column.rb
@@ -21,6 +21,15 @@ module ActiveRecord
           default_kind.materialized? || default_kind.alias?
         end
 
+        # Whether the column holds a ClickHouse `Array(...)` type.
+        #
+        # ActiveRecord core never calls this, but tooling such as annotaterb
+        # detects array columns via `column.respond_to?(:array) && column.array`,
+        # so the base adapter's missing `array` reader left them undetected.
+        def array
+          sql_type.start_with?('Array(')
+        end
+
         private
 
         def deduplicated

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -165,11 +165,11 @@ module ClickhouseActiverecord
     end
 
     def schema_array(column)
-      (column.sql_type =~ /Array\(/).nil? ? nil : true
+      column.array || nil
     end
 
     def schema_map(column)
-      if column.sql_type =~ /Map\(([^,]+),\s*(Array)\)/
+      if column.sql_type =~ /Map\(([^,]+),\s*Array\(/
         return :array
       end
 

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -165,11 +165,11 @@ module ClickhouseActiverecord
     end
 
     def schema_array(column)
-      column.array || nil
+      column.array ? true : nil
     end
 
     def schema_map(column)
-      if column.sql_type =~ /Map\(([^,]+),\s*Array\(/
+      if column.sql_type =~ /Map\([^,]+,\s*Array\(/
         return :array
       end
 

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -543,6 +543,18 @@ RSpec.describe 'Model', :migrations do
       quietly { ActiveRecord::MigrationContext.new(migrations_dir).up }
     end
 
+    describe '#array' do
+      it 'reports array columns as arrays' do
+        expect(model.columns_hash['array_datetime'].array).to be_truthy
+        expect(model.columns_hash['array_string'].array).to be_truthy
+        expect(model.columns_hash['array_int'].array).to be_truthy
+      end
+
+      it 'does not report scalar columns as arrays' do
+        expect(model.columns_hash['date'].array).to be_falsey
+      end
+    end
+
     describe '#create' do
       it 'creates a new record' do
         expect {
@@ -597,6 +609,13 @@ RSpec.describe 'Model', :migrations do
     before do
       migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'add_map_datetime')
       quietly { ActiveRecord::MigrationContext.new(migrations_dir).up }
+    end
+
+    describe '#array' do
+      it 'does not report map columns as arrays' do
+        expect(model.columns_hash['map_string'].array).to be_falsey
+        expect(model.columns_hash['map_array_string'].array).to be_falsey
+      end
     end
 
     describe '#create' do


### PR DESCRIPTION
## Summary

The base ActiveRecord `Column` does not define `array`/`array?`; each adapter that supports arrays adds it on its own `Column` subclass (e.g. PostgreSQL's `array` reader). The ClickHouse `Column` never did, so tooling that detects array columns via `column.respond_to?(:array) && column.array` — such as **annotaterb** — silently treated `Array(...)` columns as their scalar subtype and never annotated them as arrays.

## Changes

- **`clickhouse/column.rb`** — add `Column#array`, matching the top-level `Array(...)` SQL type:
  ```ruby
  def array
    sql_type.start_with?('Array(')
  end
  ```
  No `array?` alias — neither ActiveRecord core nor annotaterb (whose own `ColumnWrapper#array?` calls `@column.respond_to?(:array) && @column.array`) invokes `array?` on the adapter column.

- **`schema_dumper.rb`** — `schema_array` now reuses `column.array` instead of re-deriving array-ness from its own regex.

- **`schema_dumper.rb`** — fixed a latent bug this surfaced. The old `schema_map` regex `/Map\(([^,]+),\s*(Array)\)/` never matched real `Map(String, Array(...))` types (dead code), so map-of-array columns leaned on the previous *match-anywhere* `schema_array` to dump as `array: true, map: true`. Since the new `column.array` is top-level-only, the regex is fixed to `/Map\(([^,]+),\s*Array\(/` so those columns dump as the intended `map: :array`. Both forms reload to the identical SQL type, so this is not a behavior change to the generated schema.

## Testing

ClickHouse isn't available in the authoring environment, so the DB-backed RSpec suite wasn't run here. The logic was validated with standalone scripts against the real `sql_type` strings from the repo's own specs: array detection is correct (`Array(...)` → true; `Map(...)` and scalars → false), and every dump case round-trips to the same SQL as before. Added specs (`#array` blocks in the array and map contexts of `model_spec.rb`) exercise this against a live server in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuX7DjQbJraGcVbseB2Eob)_